### PR TITLE
M1 #10: Implement Instrument and Symbol value objects

### DIFF
--- a/src/domain/value_objects/instrument.rs
+++ b/src/domain/value_objects/instrument.rs
@@ -1,5 +1,408 @@
 //! # Instrument Value Object
 //!
 //! Trading instrument with asset class and settlement method.
+//!
+//! This module provides the [`Instrument`] type for representing tradeable
+//! instruments with their associated metadata.
+//!
+//! # Examples
+//!
+//! ```
+//! use otc_rfq::domain::value_objects::instrument::Instrument;
+//! use otc_rfq::domain::value_objects::symbol::Symbol;
+//! use otc_rfq::domain::value_objects::enums::{AssetClass, SettlementMethod, Blockchain};
+//!
+//! let symbol = Symbol::new("BTC/USD").unwrap();
+//! let instrument = Instrument::new(
+//!     symbol,
+//!     AssetClass::CryptoSpot,
+//!     SettlementMethod::OnChain(Blockchain::Ethereum),
+//! );
+//!
+//! assert_eq!(instrument.symbol().to_string(), "BTC/USD");
+//! assert!(instrument.asset_class().is_crypto());
+//! ```
 
-// TODO: Implement in M1 #10
+use super::enums::{AssetClass, SettlementMethod};
+use super::quantity::Quantity;
+use super::symbol::Symbol;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// A tradeable instrument with associated metadata.
+///
+/// Combines a trading symbol with asset classification, settlement method,
+/// and optional trading constraints.
+///
+/// # Examples
+///
+/// ```
+/// use otc_rfq::domain::value_objects::instrument::Instrument;
+/// use otc_rfq::domain::value_objects::symbol::Symbol;
+/// use otc_rfq::domain::value_objects::enums::{AssetClass, SettlementMethod, Blockchain};
+/// use otc_rfq::domain::value_objects::quantity::Quantity;
+///
+/// let symbol = Symbol::new("ETH/USDC").unwrap();
+/// let instrument = Instrument::builder(symbol, AssetClass::CryptoSpot)
+///     .settlement_method(SettlementMethod::OnChain(Blockchain::Ethereum))
+///     .min_quantity(Quantity::new(0.01).unwrap())
+///     .price_decimals(2)
+///     .build();
+///
+/// assert_eq!(instrument.price_decimals(), Some(2));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Instrument {
+    /// The trading symbol (e.g., BTC/USD).
+    symbol: Symbol,
+    /// The asset class classification.
+    asset_class: AssetClass,
+    /// The settlement method for trades.
+    settlement_method: SettlementMethod,
+    /// Minimum tradeable quantity (optional).
+    min_quantity: Option<Quantity>,
+    /// Number of decimal places for price (optional).
+    price_decimals: Option<u8>,
+}
+
+impl Instrument {
+    /// Creates a new instrument with required fields.
+    ///
+    /// Use [`Instrument::builder`] for more control over optional fields.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - The trading symbol
+    /// * `asset_class` - The asset class classification
+    /// * `settlement_method` - The settlement method
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use otc_rfq::domain::value_objects::instrument::Instrument;
+    /// use otc_rfq::domain::value_objects::symbol::Symbol;
+    /// use otc_rfq::domain::value_objects::enums::{AssetClass, SettlementMethod};
+    ///
+    /// let symbol = Symbol::new("BTC/USD").unwrap();
+    /// let instrument = Instrument::new(
+    ///     symbol,
+    ///     AssetClass::CryptoSpot,
+    ///     SettlementMethod::default(),
+    /// );
+    /// ```
+    #[must_use]
+    pub fn new(
+        symbol: Symbol,
+        asset_class: AssetClass,
+        settlement_method: SettlementMethod,
+    ) -> Self {
+        Self {
+            symbol,
+            asset_class,
+            settlement_method,
+            min_quantity: None,
+            price_decimals: None,
+        }
+    }
+
+    /// Creates a builder for constructing an instrument with optional fields.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - The trading symbol
+    /// * `asset_class` - The asset class classification
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use otc_rfq::domain::value_objects::instrument::Instrument;
+    /// use otc_rfq::domain::value_objects::symbol::Symbol;
+    /// use otc_rfq::domain::value_objects::enums::{AssetClass, SettlementMethod, Blockchain};
+    ///
+    /// let symbol = Symbol::new("ETH/USDC").unwrap();
+    /// let instrument = Instrument::builder(symbol, AssetClass::CryptoSpot)
+    ///     .settlement_method(SettlementMethod::OnChain(Blockchain::Polygon))
+    ///     .price_decimals(6)
+    ///     .build();
+    /// ```
+    #[must_use]
+    pub fn builder(symbol: Symbol, asset_class: AssetClass) -> InstrumentBuilder {
+        InstrumentBuilder::new(symbol, asset_class)
+    }
+
+    /// Returns the trading symbol.
+    #[inline]
+    #[must_use]
+    pub fn symbol(&self) -> &Symbol {
+        &self.symbol
+    }
+
+    /// Returns the base asset of the trading pair.
+    #[inline]
+    #[must_use]
+    pub fn base_asset(&self) -> &str {
+        self.symbol.base_asset()
+    }
+
+    /// Returns the quote asset of the trading pair.
+    #[inline]
+    #[must_use]
+    pub fn quote_asset(&self) -> &str {
+        self.symbol.quote_asset()
+    }
+
+    /// Returns the asset class.
+    #[inline]
+    #[must_use]
+    pub fn asset_class(&self) -> AssetClass {
+        self.asset_class
+    }
+
+    /// Returns the settlement method.
+    #[inline]
+    #[must_use]
+    pub fn settlement_method(&self) -> SettlementMethod {
+        self.settlement_method
+    }
+
+    /// Returns the minimum tradeable quantity, if set.
+    #[inline]
+    #[must_use]
+    pub fn min_quantity(&self) -> Option<Quantity> {
+        self.min_quantity
+    }
+
+    /// Returns the number of price decimal places, if set.
+    #[inline]
+    #[must_use]
+    pub fn price_decimals(&self) -> Option<u8> {
+        self.price_decimals
+    }
+
+    /// Returns true if this is a cryptocurrency instrument.
+    #[inline]
+    #[must_use]
+    pub fn is_crypto(&self) -> bool {
+        self.asset_class.is_crypto()
+    }
+
+    /// Returns true if this instrument settles on-chain.
+    #[inline]
+    #[must_use]
+    pub fn is_onchain(&self) -> bool {
+        self.settlement_method.is_onchain()
+    }
+}
+
+impl fmt::Display for Instrument {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({})", self.symbol, self.asset_class)
+    }
+}
+
+/// Builder for constructing [`Instrument`] instances.
+///
+/// Provides a fluent API for setting optional fields.
+#[derive(Debug, Clone)]
+pub struct InstrumentBuilder {
+    symbol: Symbol,
+    asset_class: AssetClass,
+    settlement_method: SettlementMethod,
+    min_quantity: Option<Quantity>,
+    price_decimals: Option<u8>,
+}
+
+impl InstrumentBuilder {
+    /// Creates a new builder with required fields.
+    fn new(symbol: Symbol, asset_class: AssetClass) -> Self {
+        Self {
+            symbol,
+            asset_class,
+            settlement_method: SettlementMethod::default(),
+            min_quantity: None,
+            price_decimals: None,
+        }
+    }
+
+    /// Sets the settlement method.
+    #[must_use]
+    pub fn settlement_method(mut self, method: SettlementMethod) -> Self {
+        self.settlement_method = method;
+        self
+    }
+
+    /// Sets the minimum tradeable quantity.
+    #[must_use]
+    pub fn min_quantity(mut self, quantity: Quantity) -> Self {
+        self.min_quantity = Some(quantity);
+        self
+    }
+
+    /// Sets the number of price decimal places.
+    #[must_use]
+    pub fn price_decimals(mut self, decimals: u8) -> Self {
+        self.price_decimals = Some(decimals);
+        self
+    }
+
+    /// Builds the instrument.
+    #[must_use]
+    pub fn build(self) -> Instrument {
+        Instrument {
+            symbol: self.symbol,
+            asset_class: self.asset_class,
+            settlement_method: self.settlement_method,
+            min_quantity: self.min_quantity,
+            price_decimals: self.price_decimals,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::domain::value_objects::enums::Blockchain;
+
+    mod construction {
+        use super::*;
+
+        #[test]
+        fn new_creates_instrument() {
+            let symbol = Symbol::new("BTC/USD").unwrap();
+            let instrument = Instrument::new(
+                symbol.clone(),
+                AssetClass::CryptoSpot,
+                SettlementMethod::OnChain(Blockchain::Ethereum),
+            );
+
+            assert_eq!(instrument.symbol(), &symbol);
+            assert_eq!(instrument.asset_class(), AssetClass::CryptoSpot);
+            assert!(instrument.settlement_method().is_onchain());
+            assert!(instrument.min_quantity().is_none());
+            assert!(instrument.price_decimals().is_none());
+        }
+
+        #[test]
+        fn builder_with_all_fields() {
+            let symbol = Symbol::new("ETH/USDC").unwrap();
+            let min_qty = Quantity::new(0.01).unwrap();
+
+            let instrument = Instrument::builder(symbol.clone(), AssetClass::CryptoSpot)
+                .settlement_method(SettlementMethod::OnChain(Blockchain::Polygon))
+                .min_quantity(min_qty)
+                .price_decimals(6)
+                .build();
+
+            assert_eq!(instrument.symbol(), &symbol);
+            assert_eq!(instrument.asset_class(), AssetClass::CryptoSpot);
+            assert_eq!(
+                instrument.settlement_method(),
+                SettlementMethod::OnChain(Blockchain::Polygon)
+            );
+            assert_eq!(instrument.min_quantity(), Some(min_qty));
+            assert_eq!(instrument.price_decimals(), Some(6));
+        }
+
+        #[test]
+        fn builder_with_defaults() {
+            let symbol = Symbol::new("SOL/USDT").unwrap();
+            let instrument = Instrument::builder(symbol, AssetClass::CryptoDerivs).build();
+
+            assert_eq!(instrument.settlement_method(), SettlementMethod::default());
+            assert!(instrument.min_quantity().is_none());
+            assert!(instrument.price_decimals().is_none());
+        }
+    }
+
+    mod accessors {
+        use super::*;
+
+        #[test]
+        fn base_and_quote_asset() {
+            let symbol = Symbol::new("BTC/USD").unwrap();
+            let instrument =
+                Instrument::new(symbol, AssetClass::CryptoSpot, SettlementMethod::default());
+
+            assert_eq!(instrument.base_asset(), "BTC");
+            assert_eq!(instrument.quote_asset(), "USD");
+        }
+
+        #[test]
+        fn is_crypto() {
+            let symbol = Symbol::new("BTC/USD").unwrap();
+
+            let crypto = Instrument::new(
+                symbol.clone(),
+                AssetClass::CryptoSpot,
+                SettlementMethod::default(),
+            );
+            assert!(crypto.is_crypto());
+
+            let stock = Instrument::new(symbol, AssetClass::Stock, SettlementMethod::OffChain);
+            assert!(!stock.is_crypto());
+        }
+
+        #[test]
+        fn is_onchain() {
+            let symbol = Symbol::new("ETH/USDC").unwrap();
+
+            let onchain = Instrument::new(
+                symbol.clone(),
+                AssetClass::CryptoSpot,
+                SettlementMethod::OnChain(Blockchain::Ethereum),
+            );
+            assert!(onchain.is_onchain());
+
+            let offchain =
+                Instrument::new(symbol, AssetClass::CryptoSpot, SettlementMethod::OffChain);
+            assert!(!offchain.is_onchain());
+        }
+    }
+
+    mod display {
+        use super::*;
+
+        #[test]
+        fn display_format() {
+            let symbol = Symbol::new("BTC/USD").unwrap();
+            let instrument =
+                Instrument::new(symbol, AssetClass::CryptoSpot, SettlementMethod::default());
+
+            assert_eq!(instrument.to_string(), "BTC/USD (CRYPTO_SPOT)");
+        }
+    }
+
+    mod serde {
+        use super::*;
+
+        #[test]
+        fn serde_roundtrip() {
+            let symbol = Symbol::new("BTC/USD").unwrap();
+            let instrument = Instrument::builder(symbol, AssetClass::CryptoSpot)
+                .settlement_method(SettlementMethod::OnChain(Blockchain::Ethereum))
+                .price_decimals(2)
+                .build();
+
+            let json = serde_json::to_string(&instrument).unwrap();
+            let deserialized: Instrument = serde_json::from_str(&json).unwrap();
+
+            assert_eq!(instrument, deserialized);
+        }
+
+        #[test]
+        fn serde_with_optional_fields() {
+            let symbol = Symbol::new("ETH/USDC").unwrap();
+            let min_qty = Quantity::new(0.1).unwrap();
+
+            let instrument = Instrument::builder(symbol, AssetClass::CryptoSpot)
+                .min_quantity(min_qty)
+                .build();
+
+            let json = serde_json::to_string(&instrument).unwrap();
+            let deserialized: Instrument = serde_json::from_str(&json).unwrap();
+
+            assert_eq!(instrument.min_quantity(), deserialized.min_quantity());
+        }
+    }
+}

--- a/src/domain/value_objects/mod.rs
+++ b/src/domain/value_objects/mod.rs
@@ -26,6 +26,11 @@
 //! - [`Blockchain`]: Supported blockchain networks
 //! - [`VenueType`]: Types of liquidity venues
 //! - [`SettlementMethod`]: On-chain or off-chain settlement
+//!
+//! ## Trading Types
+//!
+//! - [`Symbol`]: Trading pair representation (e.g., BTC/USD)
+//! - [`Instrument`]: Tradeable instrument with metadata
 
 pub mod arithmetic;
 pub mod compliance;
@@ -41,5 +46,7 @@ pub mod timestamp;
 pub use arithmetic::{div_round, ArithmeticError, ArithmeticResult, CheckedArithmetic, Rounding};
 pub use enums::{AssetClass, Blockchain, OrderSide, ParseEnumError, SettlementMethod, VenueType};
 pub use ids::{CounterpartyId, EventId, QuoteId, RfqId, TradeId, VenueId};
+pub use instrument::{Instrument, InstrumentBuilder};
 pub use price::Price;
 pub use quantity::Quantity;
+pub use symbol::{Symbol, SymbolError};

--- a/src/domain/value_objects/symbol.rs
+++ b/src/domain/value_objects/symbol.rs
@@ -1,5 +1,432 @@
 //! # Symbol Value Object
 //!
 //! Trading symbol representation.
+//!
+//! This module provides the [`Symbol`] type for representing trading pairs
+//! in the format `BASE/QUOTE` (e.g., `BTC/USD`, `ETH/USDC`).
+//!
+//! # Examples
+//!
+//! ```
+//! use otc_rfq::domain::value_objects::symbol::Symbol;
+//!
+//! let symbol = Symbol::new("BTC/USD").unwrap();
+//! assert_eq!(symbol.base_asset(), "BTC");
+//! assert_eq!(symbol.quote_asset(), "USD");
+//! ```
 
-// TODO: Implement in M1 #10
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+use thiserror::Error;
+
+/// Error type for symbol parsing and validation.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum SymbolError {
+    /// Symbol string is empty.
+    #[error("symbol cannot be empty")]
+    Empty,
+
+    /// Symbol format is invalid (missing separator).
+    #[error("invalid symbol format: expected BASE/QUOTE, got '{0}'")]
+    InvalidFormat(String),
+
+    /// Base asset is empty.
+    #[error("base asset cannot be empty")]
+    EmptyBaseAsset,
+
+    /// Quote asset is empty.
+    #[error("quote asset cannot be empty")]
+    EmptyQuoteAsset,
+
+    /// Symbol contains invalid characters.
+    #[error("symbol contains invalid characters: '{0}'")]
+    InvalidCharacters(String),
+}
+
+/// A validated trading symbol.
+///
+/// Represents a trading pair in the format `BASE/QUOTE`.
+/// Both base and quote assets are stored in uppercase.
+///
+/// # Invariants
+///
+/// - Symbol is non-empty
+/// - Format is `BASE/QUOTE` with exactly one `/` separator
+/// - Both base and quote assets are non-empty
+/// - Only alphanumeric characters allowed in asset names
+///
+/// # Examples
+///
+/// ```
+/// use otc_rfq::domain::value_objects::symbol::Symbol;
+///
+/// // Create from string
+/// let symbol = Symbol::new("btc/usd").unwrap();
+/// assert_eq!(symbol.to_string(), "BTC/USD");
+///
+/// // Parse from string
+/// let symbol: Symbol = "ETH/USDC".parse().unwrap();
+/// assert_eq!(symbol.base_asset(), "ETH");
+/// assert_eq!(symbol.quote_asset(), "USDC");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct Symbol {
+    /// The full symbol string (e.g., "BTC/USD").
+    value: String,
+    /// Index of the separator for efficient base/quote extraction.
+    separator_index: usize,
+}
+
+impl Symbol {
+    /// The separator character between base and quote assets.
+    pub const SEPARATOR: char = '/';
+
+    /// Creates a new symbol from a string.
+    ///
+    /// The input is normalized to uppercase.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The symbol string (e.g., "BTC/USD")
+    ///
+    /// # Errors
+    ///
+    /// Returns `SymbolError` if:
+    /// - The string is empty
+    /// - The format is invalid (missing or multiple separators)
+    /// - Base or quote asset is empty
+    /// - Contains invalid characters
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use otc_rfq::domain::value_objects::symbol::Symbol;
+    ///
+    /// let symbol = Symbol::new("BTC/USD").unwrap();
+    /// assert_eq!(symbol.to_string(), "BTC/USD");
+    ///
+    /// // Lowercase is normalized to uppercase
+    /// let symbol = Symbol::new("eth/usdc").unwrap();
+    /// assert_eq!(symbol.to_string(), "ETH/USDC");
+    /// ```
+    pub fn new(value: impl AsRef<str>) -> Result<Self, SymbolError> {
+        let value = value.as_ref().trim();
+
+        if value.is_empty() {
+            return Err(SymbolError::Empty);
+        }
+
+        // Normalize to uppercase
+        let normalized = value.to_uppercase();
+
+        // Find separator
+        let separator_count = normalized.matches(Self::SEPARATOR).count();
+        if separator_count != 1 {
+            return Err(SymbolError::InvalidFormat(value.to_string()));
+        }
+
+        let separator_index = normalized
+            .find(Self::SEPARATOR)
+            .ok_or_else(|| SymbolError::InvalidFormat(value.to_string()))?;
+
+        // Validate base asset
+        let base = &normalized[..separator_index];
+        if base.is_empty() {
+            return Err(SymbolError::EmptyBaseAsset);
+        }
+
+        // Validate quote asset
+        let quote = &normalized[separator_index + 1..];
+        if quote.is_empty() {
+            return Err(SymbolError::EmptyQuoteAsset);
+        }
+
+        // Validate characters (alphanumeric only)
+        if !base.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return Err(SymbolError::InvalidCharacters(base.to_string()));
+        }
+        if !quote.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return Err(SymbolError::InvalidCharacters(quote.to_string()));
+        }
+
+        Ok(Self {
+            value: normalized,
+            separator_index,
+        })
+    }
+
+    /// Returns the base asset (left side of the pair).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use otc_rfq::domain::value_objects::symbol::Symbol;
+    ///
+    /// let symbol = Symbol::new("BTC/USD").unwrap();
+    /// assert_eq!(symbol.base_asset(), "BTC");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn base_asset(&self) -> &str {
+        &self.value[..self.separator_index]
+    }
+
+    /// Returns the quote asset (right side of the pair).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use otc_rfq::domain::value_objects::symbol::Symbol;
+    ///
+    /// let symbol = Symbol::new("BTC/USD").unwrap();
+    /// assert_eq!(symbol.quote_asset(), "USD");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn quote_asset(&self) -> &str {
+        &self.value[self.separator_index + 1..]
+    }
+
+    /// Returns the full symbol string.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.value
+    }
+
+    /// Returns the inverted symbol (swap base and quote).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use otc_rfq::domain::value_objects::symbol::Symbol;
+    ///
+    /// let symbol = Symbol::new("BTC/USD").unwrap();
+    /// let inverted = symbol.invert();
+    /// assert_eq!(inverted.to_string(), "USD/BTC");
+    /// ```
+    #[must_use]
+    pub fn invert(&self) -> Self {
+        let inverted = format!("{}/{}", self.quote_asset(), self.base_asset());
+        // Safe because we're just swapping validated components
+        Self {
+            separator_index: self.value.len() - self.separator_index - 1,
+            value: inverted,
+        }
+    }
+}
+
+impl fmt::Display for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl FromStr for Symbol {
+    type Err = SymbolError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl TryFrom<String> for Symbol {
+    type Error = SymbolError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for Symbol {
+    type Error = SymbolError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<Symbol> for String {
+    fn from(symbol: Symbol) -> Self {
+        symbol.value
+    }
+}
+
+impl AsRef<str> for Symbol {
+    fn as_ref(&self) -> &str {
+        &self.value
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    mod construction {
+        use super::*;
+
+        #[test]
+        fn new_valid_symbol() {
+            let symbol = Symbol::new("BTC/USD").unwrap();
+            assert_eq!(symbol.to_string(), "BTC/USD");
+        }
+
+        #[test]
+        fn new_normalizes_to_uppercase() {
+            let symbol = Symbol::new("btc/usd").unwrap();
+            assert_eq!(symbol.to_string(), "BTC/USD");
+        }
+
+        #[test]
+        fn new_mixed_case() {
+            let symbol = Symbol::new("Eth/Usdc").unwrap();
+            assert_eq!(symbol.to_string(), "ETH/USDC");
+        }
+
+        #[test]
+        fn new_trims_whitespace() {
+            let symbol = Symbol::new("  BTC/USD  ").unwrap();
+            assert_eq!(symbol.to_string(), "BTC/USD");
+        }
+
+        #[test]
+        fn new_empty_fails() {
+            let result = Symbol::new("");
+            assert!(matches!(result, Err(SymbolError::Empty)));
+        }
+
+        #[test]
+        fn new_no_separator_fails() {
+            let result = Symbol::new("BTCUSD");
+            assert!(matches!(result, Err(SymbolError::InvalidFormat(_))));
+        }
+
+        #[test]
+        fn new_multiple_separators_fails() {
+            let result = Symbol::new("BTC/USD/EUR");
+            assert!(matches!(result, Err(SymbolError::InvalidFormat(_))));
+        }
+
+        #[test]
+        fn new_empty_base_fails() {
+            let result = Symbol::new("/USD");
+            assert!(matches!(result, Err(SymbolError::EmptyBaseAsset)));
+        }
+
+        #[test]
+        fn new_empty_quote_fails() {
+            let result = Symbol::new("BTC/");
+            assert!(matches!(result, Err(SymbolError::EmptyQuoteAsset)));
+        }
+
+        #[test]
+        fn new_invalid_characters_fails() {
+            let result = Symbol::new("BTC$/USD");
+            assert!(matches!(result, Err(SymbolError::InvalidCharacters(_))));
+        }
+    }
+
+    mod accessors {
+        use super::*;
+
+        #[test]
+        fn base_asset() {
+            let symbol = Symbol::new("BTC/USD").unwrap();
+            assert_eq!(symbol.base_asset(), "BTC");
+        }
+
+        #[test]
+        fn quote_asset() {
+            let symbol = Symbol::new("BTC/USD").unwrap();
+            assert_eq!(symbol.quote_asset(), "USD");
+        }
+
+        #[test]
+        fn as_str() {
+            let symbol = Symbol::new("ETH/USDC").unwrap();
+            assert_eq!(symbol.as_str(), "ETH/USDC");
+        }
+    }
+
+    mod invert {
+        use super::*;
+
+        #[test]
+        fn invert_swaps_base_and_quote() {
+            let symbol = Symbol::new("BTC/USD").unwrap();
+            let inverted = symbol.invert();
+            assert_eq!(inverted.to_string(), "USD/BTC");
+            assert_eq!(inverted.base_asset(), "USD");
+            assert_eq!(inverted.quote_asset(), "BTC");
+        }
+
+        #[test]
+        fn double_invert_returns_original() {
+            let symbol = Symbol::new("ETH/USDC").unwrap();
+            let double_inverted = symbol.invert().invert();
+            assert_eq!(symbol, double_inverted);
+        }
+    }
+
+    mod from_str {
+        use super::*;
+
+        #[test]
+        fn parse_works() {
+            let symbol: Symbol = "BTC/USD".parse().unwrap();
+            assert_eq!(symbol.to_string(), "BTC/USD");
+        }
+
+        #[test]
+        fn parse_invalid_fails() {
+            let result: Result<Symbol, _> = "INVALID".parse();
+            assert!(result.is_err());
+        }
+    }
+
+    mod serde {
+        use super::*;
+
+        #[test]
+        fn serde_roundtrip() {
+            let symbol = Symbol::new("BTC/USD").unwrap();
+            let json = serde_json::to_string(&symbol).unwrap();
+            assert_eq!(json, "\"BTC/USD\"");
+            let deserialized: Symbol = serde_json::from_str(&json).unwrap();
+            assert_eq!(symbol, deserialized);
+        }
+
+        #[test]
+        fn deserialize_invalid_fails() {
+            let json = "\"INVALID\"";
+            let result: Result<Symbol, _> = serde_json::from_str(json);
+            assert!(result.is_err());
+        }
+    }
+
+    mod display {
+        use super::*;
+
+        #[test]
+        fn display_format() {
+            let symbol = Symbol::new("SOL/USDT").unwrap();
+            assert_eq!(format!("{}", symbol), "SOL/USDT");
+        }
+    }
+
+    mod error {
+        use super::*;
+
+        #[test]
+        fn error_display() {
+            assert_eq!(SymbolError::Empty.to_string(), "symbol cannot be empty");
+            assert_eq!(
+                SymbolError::InvalidFormat("test".to_string()).to_string(),
+                "invalid symbol format: expected BASE/QUOTE, got 'test'"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implement Symbol and Instrument value objects for trading pair representation.

## Changes

### Symbol
- String wrapper for trading pairs (e.g., `BTC/USD`)
- Validates format: `BASE/QUOTE` with single separator
- Normalizes input to uppercase
- `base_asset()` and `quote_asset()` accessors
- `invert()` to swap base and quote
- `FromStr`, `Display`, Serde support
- `SymbolError` for validation failures

### Instrument
- Composite value object combining Symbol with metadata
- Required fields: `symbol`, `asset_class`, `settlement_method`
- Optional fields: `min_quantity`, `price_decimals`
- Builder pattern via `Instrument::builder()`
- `is_crypto()` and `is_onchain()` convenience methods

## Technical Decisions

- Used `separator_index` field for O(1) base/quote extraction
- Builder pattern allows flexible construction with optional fields
- Symbol validates alphanumeric characters only
- Instrument delegates to Symbol for base/quote asset access

## Testing

- [x] Unit tests added (30 new tests, 164 total)
- [x] Tests cover construction, validation, accessors, serde
- [x] All tests passing

## Checklist

- [x] Code follows `.internalDoc/09-rust-guidelines.md`
- [x] Documentation updated (doc comments on all public items)
- [x] No warnings from `cargo clippy`

Closes #10