### PR TITLE
M1 #19: Implement domain events for event sourcing

### DIFF
--- a/src/domain/events/compliance_events.rs
+++ b/src/domain/events/compliance_events.rs
@@ -1,5 +1,471 @@
 //! # Compliance Events
 //!
 //! Domain events for compliance checks.
+//!
+//! This module provides events that track compliance verification
+//! during the RFQ lifecycle.
 
-// TODO: Implement in M1 #19
+use crate::domain::events::domain_event::{DomainEvent, EventMetadata, EventType};
+use crate::domain::value_objects::timestamp::Timestamp;
+use crate::domain::value_objects::{CounterpartyId, EventId, RfqId};
+use serde::{Deserialize, Serialize};
+
+/// Type of compliance check performed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ComplianceCheckType {
+    /// Know Your Customer verification.
+    Kyc,
+    /// Anti-Money Laundering check.
+    Aml,
+    /// Sanctions screening.
+    Sanctions,
+    /// Trading limits check.
+    TradingLimits,
+    /// Instrument eligibility check.
+    InstrumentEligibility,
+    /// General compliance check.
+    General,
+}
+
+impl std::fmt::Display for ComplianceCheckType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Kyc => write!(f, "KYC"),
+            Self::Aml => write!(f, "AML"),
+            Self::Sanctions => write!(f, "SANCTIONS"),
+            Self::TradingLimits => write!(f, "TRADING_LIMITS"),
+            Self::InstrumentEligibility => write!(f, "INSTRUMENT_ELIGIBILITY"),
+            Self::General => write!(f, "GENERAL"),
+        }
+    }
+}
+
+/// Event emitted when a compliance check passes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComplianceCheckPassed {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The counterparty that was checked.
+    pub counterparty_id: CounterpartyId,
+    /// Type of compliance check.
+    pub check_type: ComplianceCheckType,
+    /// Optional details about the check.
+    pub details: Option<String>,
+}
+
+impl ComplianceCheckPassed {
+    /// Creates a new ComplianceCheckPassed event.
+    #[must_use]
+    pub fn new(
+        rfq_id: RfqId,
+        counterparty_id: CounterpartyId,
+        check_type: ComplianceCheckType,
+        details: Option<String>,
+    ) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            counterparty_id,
+            check_type,
+            details,
+        }
+    }
+
+    /// Creates a KYC passed event.
+    #[must_use]
+    pub fn kyc(rfq_id: RfqId, counterparty_id: CounterpartyId) -> Self {
+        Self::new(rfq_id, counterparty_id, ComplianceCheckType::Kyc, None)
+    }
+
+    /// Creates an AML passed event.
+    #[must_use]
+    pub fn aml(rfq_id: RfqId, counterparty_id: CounterpartyId) -> Self {
+        Self::new(rfq_id, counterparty_id, ComplianceCheckType::Aml, None)
+    }
+
+    /// Creates a sanctions check passed event.
+    #[must_use]
+    pub fn sanctions(rfq_id: RfqId, counterparty_id: CounterpartyId) -> Self {
+        Self::new(
+            rfq_id,
+            counterparty_id,
+            ComplianceCheckType::Sanctions,
+            None,
+        )
+    }
+
+    /// Creates a trading limits check passed event.
+    #[must_use]
+    pub fn trading_limits(rfq_id: RfqId, counterparty_id: CounterpartyId) -> Self {
+        Self::new(
+            rfq_id,
+            counterparty_id,
+            ComplianceCheckType::TradingLimits,
+            None,
+        )
+    }
+}
+
+impl DomainEvent for ComplianceCheckPassed {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Compliance
+    }
+
+    fn event_name(&self) -> &'static str {
+        "ComplianceCheckPassed"
+    }
+}
+
+/// Event emitted when a compliance check fails.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComplianceCheckFailed {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The counterparty that was checked.
+    pub counterparty_id: CounterpartyId,
+    /// Type of compliance check.
+    pub check_type: ComplianceCheckType,
+    /// Reason for failure.
+    pub reason: String,
+    /// Error code (if applicable).
+    pub error_code: Option<String>,
+}
+
+impl ComplianceCheckFailed {
+    /// Creates a new ComplianceCheckFailed event.
+    #[must_use]
+    pub fn new(
+        rfq_id: RfqId,
+        counterparty_id: CounterpartyId,
+        check_type: ComplianceCheckType,
+        reason: impl Into<String>,
+        error_code: Option<String>,
+    ) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            counterparty_id,
+            check_type,
+            reason: reason.into(),
+            error_code,
+        }
+    }
+
+    /// Creates a KYC failed event.
+    #[must_use]
+    pub fn kyc(rfq_id: RfqId, counterparty_id: CounterpartyId, reason: impl Into<String>) -> Self {
+        Self::new(
+            rfq_id,
+            counterparty_id,
+            ComplianceCheckType::Kyc,
+            reason,
+            None,
+        )
+    }
+
+    /// Creates an AML failed event.
+    #[must_use]
+    pub fn aml(rfq_id: RfqId, counterparty_id: CounterpartyId, reason: impl Into<String>) -> Self {
+        Self::new(
+            rfq_id,
+            counterparty_id,
+            ComplianceCheckType::Aml,
+            reason,
+            None,
+        )
+    }
+
+    /// Creates a sanctions check failed event.
+    #[must_use]
+    pub fn sanctions(
+        rfq_id: RfqId,
+        counterparty_id: CounterpartyId,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            rfq_id,
+            counterparty_id,
+            ComplianceCheckType::Sanctions,
+            reason,
+            None,
+        )
+    }
+
+    /// Creates a trading limits check failed event.
+    #[must_use]
+    pub fn trading_limits(
+        rfq_id: RfqId,
+        counterparty_id: CounterpartyId,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            rfq_id,
+            counterparty_id,
+            ComplianceCheckType::TradingLimits,
+            reason,
+            None,
+        )
+    }
+}
+
+impl DomainEvent for ComplianceCheckFailed {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Compliance
+    }
+
+    fn event_name(&self) -> &'static str {
+        "ComplianceCheckFailed"
+    }
+}
+
+/// Enum containing all compliance events.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ComplianceEvent {
+    /// Compliance check passed.
+    Passed(ComplianceCheckPassed),
+    /// Compliance check failed.
+    Failed(ComplianceCheckFailed),
+}
+
+impl DomainEvent for ComplianceEvent {
+    fn event_id(&self) -> EventId {
+        match self {
+            Self::Passed(e) => e.event_id(),
+            Self::Failed(e) => e.event_id(),
+        }
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        match self {
+            Self::Passed(e) => e.rfq_id(),
+            Self::Failed(e) => e.rfq_id(),
+        }
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        match self {
+            Self::Passed(e) => e.timestamp(),
+            Self::Failed(e) => e.timestamp(),
+        }
+    }
+
+    fn event_type(&self) -> EventType {
+        match self {
+            Self::Passed(e) => e.event_type(),
+            Self::Failed(e) => e.event_type(),
+        }
+    }
+
+    fn event_name(&self) -> &'static str {
+        match self {
+            Self::Passed(e) => e.event_name(),
+            Self::Failed(e) => e.event_name(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn test_rfq_id() -> RfqId {
+        RfqId::new_v4()
+    }
+
+    fn test_counterparty_id() -> CounterpartyId {
+        CounterpartyId::new("test-client")
+    }
+
+    mod compliance_check_type {
+        use super::*;
+
+        #[test]
+        fn display() {
+            assert_eq!(ComplianceCheckType::Kyc.to_string(), "KYC");
+            assert_eq!(ComplianceCheckType::Aml.to_string(), "AML");
+            assert_eq!(ComplianceCheckType::Sanctions.to_string(), "SANCTIONS");
+            assert_eq!(
+                ComplianceCheckType::TradingLimits.to_string(),
+                "TRADING_LIMITS"
+            );
+        }
+    }
+
+    mod compliance_check_passed {
+        use super::*;
+
+        #[test]
+        fn creates_event() {
+            let rfq_id = test_rfq_id();
+            let event = ComplianceCheckPassed::kyc(rfq_id, test_counterparty_id());
+
+            assert_eq!(event.rfq_id(), Some(rfq_id));
+            assert_eq!(event.check_type, ComplianceCheckType::Kyc);
+            assert_eq!(event.event_name(), "ComplianceCheckPassed");
+            assert_eq!(event.event_type(), EventType::Compliance);
+        }
+
+        #[test]
+        fn aml_check() {
+            let event = ComplianceCheckPassed::aml(test_rfq_id(), test_counterparty_id());
+            assert_eq!(event.check_type, ComplianceCheckType::Aml);
+        }
+
+        #[test]
+        fn sanctions_check() {
+            let event = ComplianceCheckPassed::sanctions(test_rfq_id(), test_counterparty_id());
+            assert_eq!(event.check_type, ComplianceCheckType::Sanctions);
+        }
+
+        #[test]
+        fn trading_limits_check() {
+            let event =
+                ComplianceCheckPassed::trading_limits(test_rfq_id(), test_counterparty_id());
+            assert_eq!(event.check_type, ComplianceCheckType::TradingLimits);
+        }
+
+        #[test]
+        fn serde_roundtrip() {
+            let event = ComplianceCheckPassed::new(
+                test_rfq_id(),
+                test_counterparty_id(),
+                ComplianceCheckType::General,
+                Some("All checks passed".to_string()),
+            );
+
+            let json = serde_json::to_string(&event).unwrap();
+            let deserialized: ComplianceCheckPassed = serde_json::from_str(&json).unwrap();
+            assert_eq!(event.check_type, deserialized.check_type);
+            assert_eq!(event.details, deserialized.details);
+        }
+    }
+
+    mod compliance_check_failed {
+        use super::*;
+
+        #[test]
+        fn creates_event() {
+            let rfq_id = test_rfq_id();
+            let event =
+                ComplianceCheckFailed::kyc(rfq_id, test_counterparty_id(), "KYC not approved");
+
+            assert_eq!(event.rfq_id(), Some(rfq_id));
+            assert_eq!(event.check_type, ComplianceCheckType::Kyc);
+            assert_eq!(event.reason, "KYC not approved");
+            assert_eq!(event.event_name(), "ComplianceCheckFailed");
+        }
+
+        #[test]
+        fn aml_failed() {
+            let event = ComplianceCheckFailed::aml(
+                test_rfq_id(),
+                test_counterparty_id(),
+                "Suspicious activity",
+            );
+            assert_eq!(event.check_type, ComplianceCheckType::Aml);
+            assert_eq!(event.reason, "Suspicious activity");
+        }
+
+        #[test]
+        fn sanctions_failed() {
+            let event = ComplianceCheckFailed::sanctions(
+                test_rfq_id(),
+                test_counterparty_id(),
+                "On sanctions list",
+            );
+            assert_eq!(event.check_type, ComplianceCheckType::Sanctions);
+        }
+
+        #[test]
+        fn trading_limits_failed() {
+            let event = ComplianceCheckFailed::trading_limits(
+                test_rfq_id(),
+                test_counterparty_id(),
+                "Daily limit exceeded",
+            );
+            assert_eq!(event.check_type, ComplianceCheckType::TradingLimits);
+        }
+
+        #[test]
+        fn with_error_code() {
+            let event = ComplianceCheckFailed::new(
+                test_rfq_id(),
+                test_counterparty_id(),
+                ComplianceCheckType::General,
+                "Check failed",
+                Some("ERR_001".to_string()),
+            );
+
+            assert_eq!(event.error_code, Some("ERR_001".to_string()));
+        }
+
+        #[test]
+        fn serde_roundtrip() {
+            let event = ComplianceCheckFailed::new(
+                test_rfq_id(),
+                test_counterparty_id(),
+                ComplianceCheckType::Aml,
+                "Failed",
+                Some("AML_001".to_string()),
+            );
+
+            let json = serde_json::to_string(&event).unwrap();
+            let deserialized: ComplianceCheckFailed = serde_json::from_str(&json).unwrap();
+            assert_eq!(event.reason, deserialized.reason);
+            assert_eq!(event.error_code, deserialized.error_code);
+        }
+    }
+
+    mod compliance_event_enum {
+        use super::*;
+
+        #[test]
+        fn serde_roundtrip() {
+            let event = ComplianceEvent::Passed(ComplianceCheckPassed::kyc(
+                test_rfq_id(),
+                test_counterparty_id(),
+            ));
+
+            let json = serde_json::to_string(&event).unwrap();
+            let deserialized: ComplianceEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(event.event_name(), deserialized.event_name());
+        }
+
+        #[test]
+        fn domain_event_trait() {
+            let event = ComplianceEvent::Failed(ComplianceCheckFailed::kyc(
+                test_rfq_id(),
+                test_counterparty_id(),
+                "Failed",
+            ));
+
+            assert_eq!(event.event_name(), "ComplianceCheckFailed");
+            assert_eq!(event.event_type(), EventType::Compliance);
+        }
+    }
+}

--- a/src/domain/events/domain_event.rs
+++ b/src/domain/events/domain_event.rs
@@ -1,5 +1,166 @@
 //! # Domain Event Trait
 //!
 //! Base trait for all domain events.
+//!
+//! This module provides the [`DomainEvent`] trait that all domain events
+//! must implement, along with common event metadata.
+//!
+//! # Examples
+//!
+//! ```
+//! use otc_rfq::domain::events::domain_event::{DomainEvent, EventType};
+//! use otc_rfq::domain::value_objects::{EventId, RfqId, Timestamp};
+//!
+//! // Events implement the DomainEvent trait
+//! // See rfq_events, trade_events, and compliance_events for concrete implementations
+//! ```
 
-// TODO: Implement in M1 #19
+use crate::domain::value_objects::timestamp::Timestamp;
+use crate::domain::value_objects::{EventId, RfqId};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Type of domain event.
+///
+/// Categorizes events by their domain area.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum EventType {
+    /// RFQ lifecycle events.
+    Rfq,
+    /// Quote-related events.
+    Quote,
+    /// Trade execution events.
+    Trade,
+    /// Settlement events.
+    Settlement,
+    /// Compliance events.
+    Compliance,
+}
+
+impl fmt::Display for EventType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Rfq => write!(f, "RFQ"),
+            Self::Quote => write!(f, "QUOTE"),
+            Self::Trade => write!(f, "TRADE"),
+            Self::Settlement => write!(f, "SETTLEMENT"),
+            Self::Compliance => write!(f, "COMPLIANCE"),
+        }
+    }
+}
+
+/// Trait for all domain events.
+///
+/// Domain events represent significant occurrences in the domain that
+/// other parts of the system may need to react to. They are immutable
+/// records of what happened.
+///
+/// # Required Methods
+///
+/// - [`event_id`](DomainEvent::event_id) - Unique identifier for this event
+/// - [`rfq_id`](DomainEvent::rfq_id) - The RFQ this event relates to (if any)
+/// - [`timestamp`](DomainEvent::timestamp) - When the event occurred
+/// - [`event_type`](DomainEvent::event_type) - Category of the event
+/// - [`event_name`](DomainEvent::event_name) - Human-readable event name
+pub trait DomainEvent: Send + Sync + fmt::Debug {
+    /// Returns the unique identifier for this event.
+    fn event_id(&self) -> EventId;
+
+    /// Returns the RFQ ID this event relates to, if any.
+    fn rfq_id(&self) -> Option<RfqId>;
+
+    /// Returns when this event occurred.
+    fn timestamp(&self) -> Timestamp;
+
+    /// Returns the type/category of this event.
+    fn event_type(&self) -> EventType;
+
+    /// Returns the human-readable name of this event.
+    fn event_name(&self) -> &'static str;
+}
+
+/// Common metadata for all domain events.
+///
+/// This struct contains the fields common to all events and can be
+/// embedded in concrete event types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventMetadata {
+    /// Unique identifier for this event.
+    pub event_id: EventId,
+    /// The RFQ this event relates to.
+    pub rfq_id: Option<RfqId>,
+    /// When this event occurred.
+    pub timestamp: Timestamp,
+}
+
+impl EventMetadata {
+    /// Creates new event metadata with a generated event ID.
+    #[must_use]
+    pub fn new(rfq_id: Option<RfqId>) -> Self {
+        Self {
+            event_id: EventId::new_v4(),
+            rfq_id,
+            timestamp: Timestamp::now(),
+        }
+    }
+
+    /// Creates new event metadata for a specific RFQ.
+    #[must_use]
+    pub fn for_rfq(rfq_id: RfqId) -> Self {
+        Self::new(Some(rfq_id))
+    }
+
+    /// Creates event metadata with specific values (for reconstruction).
+    #[must_use]
+    pub fn from_parts(event_id: EventId, rfq_id: Option<RfqId>, timestamp: Timestamp) -> Self {
+        Self {
+            event_id,
+            rfq_id,
+            timestamp,
+        }
+    }
+}
+
+impl Default for EventMetadata {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_type_display() {
+        assert_eq!(EventType::Rfq.to_string(), "RFQ");
+        assert_eq!(EventType::Quote.to_string(), "QUOTE");
+        assert_eq!(EventType::Trade.to_string(), "TRADE");
+        assert_eq!(EventType::Settlement.to_string(), "SETTLEMENT");
+        assert_eq!(EventType::Compliance.to_string(), "COMPLIANCE");
+    }
+
+    #[test]
+    fn event_metadata_new() {
+        let metadata = EventMetadata::new(None);
+        assert!(metadata.rfq_id.is_none());
+    }
+
+    #[test]
+    fn event_metadata_for_rfq() {
+        let rfq_id = RfqId::new_v4();
+        let metadata = EventMetadata::for_rfq(rfq_id);
+        assert_eq!(metadata.rfq_id, Some(rfq_id));
+    }
+
+    #[test]
+    fn event_metadata_serde_roundtrip() {
+        let metadata = EventMetadata::new(Some(RfqId::new_v4()));
+        let json = serde_json::to_string(&metadata).unwrap();
+        let deserialized: EventMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(metadata.event_id, deserialized.event_id);
+        assert_eq!(metadata.rfq_id, deserialized.rfq_id);
+    }
+}

--- a/src/domain/events/mod.rs
+++ b/src/domain/events/mod.rs
@@ -4,17 +4,44 @@
 //!
 //! ## RFQ Events
 //!
-//! - `RfqCreated`: New RFQ initiated
-//! - `QuoteReceived`: Quote received from venue
-//! - `QuoteSelected`: Client selected a quote
-//! - `TradeExecuted`: Trade successfully executed
+//! - [`RfqCreated`]: New RFQ initiated
+//! - [`QuoteCollectionStarted`]: Quote collection begins
+//! - [`QuoteRequested`]: Quote requested from venue
+//! - [`QuoteReceived`]: Quote received from venue
+//! - [`QuoteRequestFailed`]: Quote request failed
+//! - [`QuoteCollectionCompleted`]: Quote collection finished
+//! - [`QuoteSelected`]: Client selected a quote
+//! - [`ExecutionStarted`]: Trade execution begins
+//! - [`ExecutionFailed`]: Trade execution failed
+//! - [`RfqCancelled`]: RFQ was cancelled
+//! - [`RfqExpired`]: RFQ expired
 //!
-//! ## Settlement Events
+//! ## Trade Events
 //!
-//! - `SettlementInitiated`: Settlement process started
-//! - `SettlementConfirmed`: Settlement completed successfully
+//! - [`TradeExecuted`]: Trade successfully executed
+//! - [`SettlementInitiated`]: Settlement process started
+//! - [`SettlementConfirmed`]: Settlement completed successfully
+//! - [`SettlementFailed`]: Settlement failed
+//!
+//! ## Compliance Events
+//!
+//! - [`ComplianceCheckPassed`]: Compliance check passed
+//! - [`ComplianceCheckFailed`]: Compliance check failed
 
 pub mod compliance_events;
 pub mod domain_event;
 pub mod rfq_events;
 pub mod trade_events;
+
+pub use compliance_events::{
+    ComplianceCheckFailed, ComplianceCheckPassed, ComplianceCheckType, ComplianceEvent,
+};
+pub use domain_event::{DomainEvent, EventMetadata, EventType};
+pub use rfq_events::{
+    ExecutionFailed, ExecutionStarted, QuoteCollectionCompleted, QuoteCollectionStarted,
+    QuoteReceived, QuoteRequestFailed, QuoteRequested, QuoteSelected, RfqCancelled, RfqCreated,
+    RfqEvent, RfqExpired,
+};
+pub use trade_events::{
+    SettlementConfirmed, SettlementFailed, SettlementInitiated, TradeEvent, TradeExecuted,
+};

--- a/src/domain/events/rfq_events.rs
+++ b/src/domain/events/rfq_events.rs
@@ -1,5 +1,868 @@
 //! # RFQ Events
 //!
 //! Domain events for RFQ lifecycle.
+//!
+//! This module provides events that track the lifecycle of an RFQ from
+//! creation through quote collection, selection, and execution.
+//!
+//! # Event Flow
+//!
+//! ```text
+//! RfqCreated -> QuoteCollectionStarted -> QuoteRequested* -> QuoteReceived*
+//!            -> QuoteCollectionCompleted -> QuoteSelected -> ExecutionStarted
+//!            -> TradeExecuted | ExecutionFailed
+//!
+//! At any point: RfqCancelled | RfqExpired
+//! ```
 
-// TODO: Implement in M1 #19
+use crate::domain::events::domain_event::{DomainEvent, EventMetadata, EventType};
+use crate::domain::value_objects::timestamp::Timestamp;
+use crate::domain::value_objects::{
+    CounterpartyId, EventId, Instrument, OrderSide, Price, Quantity, QuoteId, RfqId, RfqState,
+    VenueId,
+};
+use serde::{Deserialize, Serialize};
+
+/// Event emitted when a new RFQ is created.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RfqCreated {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The client who created the RFQ.
+    pub client_id: CounterpartyId,
+    /// The instrument being traded.
+    pub instrument: Instrument,
+    /// Buy or sell.
+    pub side: OrderSide,
+    /// Requested quantity.
+    pub quantity: Quantity,
+    /// When the RFQ expires.
+    pub expires_at: Timestamp,
+}
+
+impl RfqCreated {
+    /// Creates a new RfqCreated event.
+    #[must_use]
+    pub fn new(
+        rfq_id: RfqId,
+        client_id: CounterpartyId,
+        instrument: Instrument,
+        side: OrderSide,
+        quantity: Quantity,
+        expires_at: Timestamp,
+    ) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            client_id,
+            instrument,
+            side,
+            quantity,
+            expires_at,
+        }
+    }
+}
+
+impl DomainEvent for RfqCreated {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Rfq
+    }
+
+    fn event_name(&self) -> &'static str {
+        "RfqCreated"
+    }
+}
+
+/// Event emitted when quote collection starts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuoteCollectionStarted {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// Venues being queried.
+    pub venue_ids: Vec<VenueId>,
+}
+
+impl QuoteCollectionStarted {
+    /// Creates a new QuoteCollectionStarted event.
+    #[must_use]
+    pub fn new(rfq_id: RfqId, venue_ids: Vec<VenueId>) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            venue_ids,
+        }
+    }
+}
+
+impl DomainEvent for QuoteCollectionStarted {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Quote
+    }
+
+    fn event_name(&self) -> &'static str {
+        "QuoteCollectionStarted"
+    }
+}
+
+/// Event emitted when a quote is requested from a venue.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuoteRequested {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The venue being queried.
+    pub venue_id: VenueId,
+}
+
+impl QuoteRequested {
+    /// Creates a new QuoteRequested event.
+    #[must_use]
+    pub fn new(rfq_id: RfqId, venue_id: VenueId) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            venue_id,
+        }
+    }
+}
+
+impl DomainEvent for QuoteRequested {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Quote
+    }
+
+    fn event_name(&self) -> &'static str {
+        "QuoteRequested"
+    }
+}
+
+/// Event emitted when a quote is received from a venue.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuoteReceived {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The quote ID.
+    pub quote_id: QuoteId,
+    /// The venue that provided the quote.
+    pub venue_id: VenueId,
+    /// The quoted price.
+    pub price: Price,
+    /// The quoted quantity.
+    pub quantity: Quantity,
+    /// When the quote expires.
+    pub valid_until: Timestamp,
+}
+
+impl QuoteReceived {
+    /// Creates a new QuoteReceived event.
+    #[must_use]
+    pub fn new(
+        rfq_id: RfqId,
+        quote_id: QuoteId,
+        venue_id: VenueId,
+        price: Price,
+        quantity: Quantity,
+        valid_until: Timestamp,
+    ) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            quote_id,
+            venue_id,
+            price,
+            quantity,
+            valid_until,
+        }
+    }
+}
+
+impl DomainEvent for QuoteReceived {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Quote
+    }
+
+    fn event_name(&self) -> &'static str {
+        "QuoteReceived"
+    }
+}
+
+/// Event emitted when a quote request fails.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuoteRequestFailed {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The venue that failed.
+    pub venue_id: VenueId,
+    /// Reason for failure.
+    pub reason: String,
+}
+
+impl QuoteRequestFailed {
+    /// Creates a new QuoteRequestFailed event.
+    #[must_use]
+    pub fn new(rfq_id: RfqId, venue_id: VenueId, reason: impl Into<String>) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            venue_id,
+            reason: reason.into(),
+        }
+    }
+}
+
+impl DomainEvent for QuoteRequestFailed {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Quote
+    }
+
+    fn event_name(&self) -> &'static str {
+        "QuoteRequestFailed"
+    }
+}
+
+/// Event emitted when quote collection is complete.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuoteCollectionCompleted {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// Number of quotes received.
+    pub quotes_received: u32,
+    /// Number of venues that failed.
+    pub venues_failed: u32,
+}
+
+impl QuoteCollectionCompleted {
+    /// Creates a new QuoteCollectionCompleted event.
+    #[must_use]
+    pub fn new(rfq_id: RfqId, quotes_received: u32, venues_failed: u32) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            quotes_received,
+            venues_failed,
+        }
+    }
+}
+
+impl DomainEvent for QuoteCollectionCompleted {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Quote
+    }
+
+    fn event_name(&self) -> &'static str {
+        "QuoteCollectionCompleted"
+    }
+}
+
+/// Event emitted when a quote is selected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuoteSelected {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The selected quote ID.
+    pub quote_id: QuoteId,
+    /// The venue providing the selected quote.
+    pub venue_id: VenueId,
+    /// The selected price.
+    pub price: Price,
+}
+
+impl QuoteSelected {
+    /// Creates a new QuoteSelected event.
+    #[must_use]
+    pub fn new(rfq_id: RfqId, quote_id: QuoteId, venue_id: VenueId, price: Price) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            quote_id,
+            venue_id,
+            price,
+        }
+    }
+}
+
+impl DomainEvent for QuoteSelected {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Quote
+    }
+
+    fn event_name(&self) -> &'static str {
+        "QuoteSelected"
+    }
+}
+
+/// Event emitted when execution starts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionStarted {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The quote being executed.
+    pub quote_id: QuoteId,
+    /// The venue executing the trade.
+    pub venue_id: VenueId,
+}
+
+impl ExecutionStarted {
+    /// Creates a new ExecutionStarted event.
+    #[must_use]
+    pub fn new(rfq_id: RfqId, quote_id: QuoteId, venue_id: VenueId) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            quote_id,
+            venue_id,
+        }
+    }
+}
+
+impl DomainEvent for ExecutionStarted {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Trade
+    }
+
+    fn event_name(&self) -> &'static str {
+        "ExecutionStarted"
+    }
+}
+
+/// Event emitted when execution fails.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionFailed {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The quote that failed to execute.
+    pub quote_id: QuoteId,
+    /// Reason for failure.
+    pub reason: String,
+}
+
+impl ExecutionFailed {
+    /// Creates a new ExecutionFailed event.
+    #[must_use]
+    pub fn new(rfq_id: RfqId, quote_id: QuoteId, reason: impl Into<String>) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            quote_id,
+            reason: reason.into(),
+        }
+    }
+}
+
+impl DomainEvent for ExecutionFailed {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Trade
+    }
+
+    fn event_name(&self) -> &'static str {
+        "ExecutionFailed"
+    }
+}
+
+/// Event emitted when an RFQ is cancelled.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RfqCancelled {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The state the RFQ was in when cancelled.
+    pub previous_state: RfqState,
+    /// Reason for cancellation.
+    pub reason: Option<String>,
+}
+
+impl RfqCancelled {
+    /// Creates a new RfqCancelled event.
+    #[must_use]
+    pub fn new(rfq_id: RfqId, previous_state: RfqState, reason: Option<String>) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            previous_state,
+            reason,
+        }
+    }
+}
+
+impl DomainEvent for RfqCancelled {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Rfq
+    }
+
+    fn event_name(&self) -> &'static str {
+        "RfqCancelled"
+    }
+}
+
+/// Event emitted when an RFQ expires.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RfqExpired {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The state the RFQ was in when it expired.
+    pub previous_state: RfqState,
+}
+
+impl RfqExpired {
+    /// Creates a new RfqExpired event.
+    #[must_use]
+    pub fn new(rfq_id: RfqId, previous_state: RfqState) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            previous_state,
+        }
+    }
+}
+
+impl DomainEvent for RfqExpired {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Rfq
+    }
+
+    fn event_name(&self) -> &'static str {
+        "RfqExpired"
+    }
+}
+
+/// Enum containing all RFQ-related events.
+///
+/// This enum allows for type-safe handling of all RFQ events.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum RfqEvent {
+    /// RFQ was created.
+    Created(RfqCreated),
+    /// Quote collection started.
+    QuoteCollectionStarted(QuoteCollectionStarted),
+    /// Quote was requested from a venue.
+    QuoteRequested(QuoteRequested),
+    /// Quote was received from a venue.
+    QuoteReceived(QuoteReceived),
+    /// Quote request failed.
+    QuoteRequestFailed(QuoteRequestFailed),
+    /// Quote collection completed.
+    QuoteCollectionCompleted(QuoteCollectionCompleted),
+    /// Quote was selected.
+    QuoteSelected(QuoteSelected),
+    /// Execution started.
+    ExecutionStarted(ExecutionStarted),
+    /// Execution failed.
+    ExecutionFailed(ExecutionFailed),
+    /// RFQ was cancelled.
+    Cancelled(RfqCancelled),
+    /// RFQ expired.
+    Expired(RfqExpired),
+}
+
+impl DomainEvent for RfqEvent {
+    fn event_id(&self) -> EventId {
+        match self {
+            Self::Created(e) => e.event_id(),
+            Self::QuoteCollectionStarted(e) => e.event_id(),
+            Self::QuoteRequested(e) => e.event_id(),
+            Self::QuoteReceived(e) => e.event_id(),
+            Self::QuoteRequestFailed(e) => e.event_id(),
+            Self::QuoteCollectionCompleted(e) => e.event_id(),
+            Self::QuoteSelected(e) => e.event_id(),
+            Self::ExecutionStarted(e) => e.event_id(),
+            Self::ExecutionFailed(e) => e.event_id(),
+            Self::Cancelled(e) => e.event_id(),
+            Self::Expired(e) => e.event_id(),
+        }
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        match self {
+            Self::Created(e) => e.rfq_id(),
+            Self::QuoteCollectionStarted(e) => e.rfq_id(),
+            Self::QuoteRequested(e) => e.rfq_id(),
+            Self::QuoteReceived(e) => e.rfq_id(),
+            Self::QuoteRequestFailed(e) => e.rfq_id(),
+            Self::QuoteCollectionCompleted(e) => e.rfq_id(),
+            Self::QuoteSelected(e) => e.rfq_id(),
+            Self::ExecutionStarted(e) => e.rfq_id(),
+            Self::ExecutionFailed(e) => e.rfq_id(),
+            Self::Cancelled(e) => e.rfq_id(),
+            Self::Expired(e) => e.rfq_id(),
+        }
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        match self {
+            Self::Created(e) => e.timestamp(),
+            Self::QuoteCollectionStarted(e) => e.timestamp(),
+            Self::QuoteRequested(e) => e.timestamp(),
+            Self::QuoteReceived(e) => e.timestamp(),
+            Self::QuoteRequestFailed(e) => e.timestamp(),
+            Self::QuoteCollectionCompleted(e) => e.timestamp(),
+            Self::QuoteSelected(e) => e.timestamp(),
+            Self::ExecutionStarted(e) => e.timestamp(),
+            Self::ExecutionFailed(e) => e.timestamp(),
+            Self::Cancelled(e) => e.timestamp(),
+            Self::Expired(e) => e.timestamp(),
+        }
+    }
+
+    fn event_type(&self) -> EventType {
+        match self {
+            Self::Created(e) => e.event_type(),
+            Self::QuoteCollectionStarted(e) => e.event_type(),
+            Self::QuoteRequested(e) => e.event_type(),
+            Self::QuoteReceived(e) => e.event_type(),
+            Self::QuoteRequestFailed(e) => e.event_type(),
+            Self::QuoteCollectionCompleted(e) => e.event_type(),
+            Self::QuoteSelected(e) => e.event_type(),
+            Self::ExecutionStarted(e) => e.event_type(),
+            Self::ExecutionFailed(e) => e.event_type(),
+            Self::Cancelled(e) => e.event_type(),
+            Self::Expired(e) => e.event_type(),
+        }
+    }
+
+    fn event_name(&self) -> &'static str {
+        match self {
+            Self::Created(e) => e.event_name(),
+            Self::QuoteCollectionStarted(e) => e.event_name(),
+            Self::QuoteRequested(e) => e.event_name(),
+            Self::QuoteReceived(e) => e.event_name(),
+            Self::QuoteRequestFailed(e) => e.event_name(),
+            Self::QuoteCollectionCompleted(e) => e.event_name(),
+            Self::QuoteSelected(e) => e.event_name(),
+            Self::ExecutionStarted(e) => e.event_name(),
+            Self::ExecutionFailed(e) => e.event_name(),
+            Self::Cancelled(e) => e.event_name(),
+            Self::Expired(e) => e.event_name(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::domain::value_objects::{AssetClass, Symbol};
+
+    fn test_rfq_id() -> RfqId {
+        RfqId::new_v4()
+    }
+
+    fn test_venue_id() -> VenueId {
+        VenueId::new("test-venue")
+    }
+
+    fn test_client_id() -> CounterpartyId {
+        CounterpartyId::new("test-client")
+    }
+
+    fn test_instrument() -> Instrument {
+        Instrument::builder(Symbol::new("BTC/USD").unwrap(), AssetClass::CryptoSpot).build()
+    }
+
+    mod rfq_created {
+        use super::*;
+
+        #[test]
+        fn creates_event() {
+            let rfq_id = test_rfq_id();
+            let event = RfqCreated::new(
+                rfq_id,
+                test_client_id(),
+                test_instrument(),
+                OrderSide::Buy,
+                Quantity::new(100.0).unwrap(),
+                Timestamp::now().add_secs(300),
+            );
+
+            assert_eq!(event.rfq_id(), Some(rfq_id));
+            assert_eq!(event.event_name(), "RfqCreated");
+            assert_eq!(event.event_type(), EventType::Rfq);
+        }
+
+        #[test]
+        fn serde_roundtrip() {
+            let event = RfqCreated::new(
+                test_rfq_id(),
+                test_client_id(),
+                test_instrument(),
+                OrderSide::Buy,
+                Quantity::new(100.0).unwrap(),
+                Timestamp::now().add_secs(300),
+            );
+
+            let json = serde_json::to_string(&event).unwrap();
+            let deserialized: RfqCreated = serde_json::from_str(&json).unwrap();
+            assert_eq!(event.metadata.event_id, deserialized.metadata.event_id);
+        }
+    }
+
+    mod quote_events {
+        use super::*;
+
+        #[test]
+        fn quote_collection_started() {
+            let rfq_id = test_rfq_id();
+            let event = QuoteCollectionStarted::new(rfq_id, vec![test_venue_id()]);
+
+            assert_eq!(event.rfq_id(), Some(rfq_id));
+            assert_eq!(event.event_name(), "QuoteCollectionStarted");
+            assert_eq!(event.venue_ids.len(), 1);
+        }
+
+        #[test]
+        fn quote_requested() {
+            let rfq_id = test_rfq_id();
+            let venue_id = test_venue_id();
+            let event = QuoteRequested::new(rfq_id, venue_id.clone());
+
+            assert_eq!(event.venue_id, venue_id);
+            assert_eq!(event.event_name(), "QuoteRequested");
+        }
+
+        #[test]
+        fn quote_received() {
+            let rfq_id = test_rfq_id();
+            let quote_id = QuoteId::new_v4();
+            let event = QuoteReceived::new(
+                rfq_id,
+                quote_id,
+                test_venue_id(),
+                Price::new(50000.0).unwrap(),
+                Quantity::new(1.0).unwrap(),
+                Timestamp::now().add_secs(60),
+            );
+
+            assert_eq!(event.quote_id, quote_id);
+            assert_eq!(event.event_name(), "QuoteReceived");
+        }
+
+        #[test]
+        fn quote_request_failed() {
+            let event = QuoteRequestFailed::new(test_rfq_id(), test_venue_id(), "Timeout");
+
+            assert_eq!(event.reason, "Timeout");
+            assert_eq!(event.event_name(), "QuoteRequestFailed");
+        }
+
+        #[test]
+        fn quote_collection_completed() {
+            let event = QuoteCollectionCompleted::new(test_rfq_id(), 3, 1);
+
+            assert_eq!(event.quotes_received, 3);
+            assert_eq!(event.venues_failed, 1);
+            assert_eq!(event.event_name(), "QuoteCollectionCompleted");
+        }
+
+        #[test]
+        fn quote_selected() {
+            let quote_id = QuoteId::new_v4();
+            let event = QuoteSelected::new(
+                test_rfq_id(),
+                quote_id,
+                test_venue_id(),
+                Price::new(50000.0).unwrap(),
+            );
+
+            assert_eq!(event.quote_id, quote_id);
+            assert_eq!(event.event_name(), "QuoteSelected");
+        }
+    }
+
+    mod execution_events {
+        use super::*;
+
+        #[test]
+        fn execution_started() {
+            let quote_id = QuoteId::new_v4();
+            let event = ExecutionStarted::new(test_rfq_id(), quote_id, test_venue_id());
+
+            assert_eq!(event.quote_id, quote_id);
+            assert_eq!(event.event_name(), "ExecutionStarted");
+            assert_eq!(event.event_type(), EventType::Trade);
+        }
+
+        #[test]
+        fn execution_failed() {
+            let quote_id = QuoteId::new_v4();
+            let event = ExecutionFailed::new(test_rfq_id(), quote_id, "Insufficient liquidity");
+
+            assert_eq!(event.reason, "Insufficient liquidity");
+            assert_eq!(event.event_name(), "ExecutionFailed");
+        }
+    }
+
+    mod rfq_lifecycle {
+        use super::*;
+
+        #[test]
+        fn rfq_cancelled() {
+            let event = RfqCancelled::new(
+                test_rfq_id(),
+                RfqState::QuotesReceived,
+                Some("Client requested".to_string()),
+            );
+
+            assert_eq!(event.previous_state, RfqState::QuotesReceived);
+            assert_eq!(event.reason, Some("Client requested".to_string()));
+            assert_eq!(event.event_name(), "RfqCancelled");
+        }
+
+        #[test]
+        fn rfq_expired() {
+            let event = RfqExpired::new(test_rfq_id(), RfqState::QuoteRequesting);
+
+            assert_eq!(event.previous_state, RfqState::QuoteRequesting);
+            assert_eq!(event.event_name(), "RfqExpired");
+        }
+    }
+
+    mod rfq_event_enum {
+        use super::*;
+
+        #[test]
+        fn serde_roundtrip() {
+            let event = RfqEvent::Created(RfqCreated::new(
+                test_rfq_id(),
+                test_client_id(),
+                test_instrument(),
+                OrderSide::Buy,
+                Quantity::new(100.0).unwrap(),
+                Timestamp::now().add_secs(300),
+            ));
+
+            let json = serde_json::to_string(&event).unwrap();
+            let deserialized: RfqEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(event.event_name(), deserialized.event_name());
+        }
+
+        #[test]
+        fn domain_event_trait() {
+            let event = RfqEvent::QuoteCollectionStarted(QuoteCollectionStarted::new(
+                test_rfq_id(),
+                vec![test_venue_id()],
+            ));
+
+            assert_eq!(event.event_name(), "QuoteCollectionStarted");
+            assert_eq!(event.event_type(), EventType::Quote);
+        }
+    }
+}

--- a/src/domain/events/trade_events.rs
+++ b/src/domain/events/trade_events.rs
@@ -1,5 +1,517 @@
 //! # Trade Events
 //!
 //! Domain events for trade and settlement lifecycle.
+//!
+//! This module provides events that track trade execution and settlement.
+//!
+//! # Event Flow
+//!
+//! ```text
+//! TradeExecuted -> SettlementInitiated -> SettlementConfirmed | SettlementFailed
+//! ```
 
-// TODO: Implement in M1 #19
+use crate::domain::events::domain_event::{DomainEvent, EventMetadata, EventType};
+use crate::domain::value_objects::timestamp::Timestamp;
+use crate::domain::value_objects::{
+    Blockchain, CounterpartyId, EventId, Price, Quantity, QuoteId, RfqId, SettlementMethod,
+    TradeId, VenueId,
+};
+use serde::{Deserialize, Serialize};
+
+/// Event emitted when a trade is executed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TradeExecuted {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The trade ID.
+    pub trade_id: TradeId,
+    /// The quote that was executed.
+    pub quote_id: QuoteId,
+    /// The venue where the trade was executed.
+    pub venue_id: VenueId,
+    /// The counterparty (client).
+    pub counterparty_id: CounterpartyId,
+    /// The execution price.
+    pub price: Price,
+    /// The executed quantity.
+    pub quantity: Quantity,
+    /// The settlement method.
+    pub settlement_method: SettlementMethod,
+}
+
+impl TradeExecuted {
+    /// Creates a new TradeExecuted event.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        rfq_id: RfqId,
+        trade_id: TradeId,
+        quote_id: QuoteId,
+        venue_id: VenueId,
+        counterparty_id: CounterpartyId,
+        price: Price,
+        quantity: Quantity,
+        settlement_method: SettlementMethod,
+    ) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            trade_id,
+            quote_id,
+            venue_id,
+            counterparty_id,
+            price,
+            quantity,
+            settlement_method,
+        }
+    }
+}
+
+impl DomainEvent for TradeExecuted {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Trade
+    }
+
+    fn event_name(&self) -> &'static str {
+        "TradeExecuted"
+    }
+}
+
+/// Event emitted when settlement is initiated.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SettlementInitiated {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The trade being settled.
+    pub trade_id: TradeId,
+    /// The settlement method.
+    pub settlement_method: SettlementMethod,
+    /// Transaction hash for on-chain settlement (if applicable).
+    pub tx_hash: Option<String>,
+}
+
+impl SettlementInitiated {
+    /// Creates a new SettlementInitiated event.
+    #[must_use]
+    pub fn new(
+        rfq_id: RfqId,
+        trade_id: TradeId,
+        settlement_method: SettlementMethod,
+        tx_hash: Option<String>,
+    ) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            trade_id,
+            settlement_method,
+            tx_hash,
+        }
+    }
+
+    /// Creates a new SettlementInitiated event for on-chain settlement.
+    #[must_use]
+    pub fn on_chain(
+        rfq_id: RfqId,
+        trade_id: TradeId,
+        blockchain: Blockchain,
+        tx_hash: String,
+    ) -> Self {
+        Self::new(
+            rfq_id,
+            trade_id,
+            SettlementMethod::OnChain(blockchain),
+            Some(tx_hash),
+        )
+    }
+
+    /// Creates a new SettlementInitiated event for off-chain settlement.
+    #[must_use]
+    pub fn off_chain(rfq_id: RfqId, trade_id: TradeId) -> Self {
+        Self::new(rfq_id, trade_id, SettlementMethod::OffChain, None)
+    }
+}
+
+impl DomainEvent for SettlementInitiated {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Settlement
+    }
+
+    fn event_name(&self) -> &'static str {
+        "SettlementInitiated"
+    }
+}
+
+/// Event emitted when settlement is confirmed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SettlementConfirmed {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The trade that was settled.
+    pub trade_id: TradeId,
+    /// Transaction hash for on-chain settlement (if applicable).
+    pub tx_hash: Option<String>,
+    /// Block number for on-chain settlement (if applicable).
+    pub block_number: Option<u64>,
+}
+
+impl SettlementConfirmed {
+    /// Creates a new SettlementConfirmed event.
+    #[must_use]
+    pub fn new(
+        rfq_id: RfqId,
+        trade_id: TradeId,
+        tx_hash: Option<String>,
+        block_number: Option<u64>,
+    ) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            trade_id,
+            tx_hash,
+            block_number,
+        }
+    }
+
+    /// Creates a new SettlementConfirmed event for on-chain settlement.
+    #[must_use]
+    pub fn on_chain(rfq_id: RfqId, trade_id: TradeId, tx_hash: String, block_number: u64) -> Self {
+        Self::new(rfq_id, trade_id, Some(tx_hash), Some(block_number))
+    }
+
+    /// Creates a new SettlementConfirmed event for off-chain settlement.
+    #[must_use]
+    pub fn off_chain(rfq_id: RfqId, trade_id: TradeId) -> Self {
+        Self::new(rfq_id, trade_id, None, None)
+    }
+}
+
+impl DomainEvent for SettlementConfirmed {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Settlement
+    }
+
+    fn event_name(&self) -> &'static str {
+        "SettlementConfirmed"
+    }
+}
+
+/// Event emitted when settlement fails.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SettlementFailed {
+    /// Event metadata.
+    pub metadata: EventMetadata,
+    /// The trade that failed to settle.
+    pub trade_id: TradeId,
+    /// Reason for failure.
+    pub reason: String,
+    /// Transaction hash if the failure was on-chain.
+    pub tx_hash: Option<String>,
+}
+
+impl SettlementFailed {
+    /// Creates a new SettlementFailed event.
+    #[must_use]
+    pub fn new(
+        rfq_id: RfqId,
+        trade_id: TradeId,
+        reason: impl Into<String>,
+        tx_hash: Option<String>,
+    ) -> Self {
+        Self {
+            metadata: EventMetadata::for_rfq(rfq_id),
+            trade_id,
+            reason: reason.into(),
+            tx_hash,
+        }
+    }
+}
+
+impl DomainEvent for SettlementFailed {
+    fn event_id(&self) -> EventId {
+        self.metadata.event_id
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        self.metadata.rfq_id
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.metadata.timestamp
+    }
+
+    fn event_type(&self) -> EventType {
+        EventType::Settlement
+    }
+
+    fn event_name(&self) -> &'static str {
+        "SettlementFailed"
+    }
+}
+
+/// Enum containing all trade and settlement events.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum TradeEvent {
+    /// Trade was executed.
+    Executed(TradeExecuted),
+    /// Settlement was initiated.
+    SettlementInitiated(SettlementInitiated),
+    /// Settlement was confirmed.
+    SettlementConfirmed(SettlementConfirmed),
+    /// Settlement failed.
+    SettlementFailed(SettlementFailed),
+}
+
+impl DomainEvent for TradeEvent {
+    fn event_id(&self) -> EventId {
+        match self {
+            Self::Executed(e) => e.event_id(),
+            Self::SettlementInitiated(e) => e.event_id(),
+            Self::SettlementConfirmed(e) => e.event_id(),
+            Self::SettlementFailed(e) => e.event_id(),
+        }
+    }
+
+    fn rfq_id(&self) -> Option<RfqId> {
+        match self {
+            Self::Executed(e) => e.rfq_id(),
+            Self::SettlementInitiated(e) => e.rfq_id(),
+            Self::SettlementConfirmed(e) => e.rfq_id(),
+            Self::SettlementFailed(e) => e.rfq_id(),
+        }
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        match self {
+            Self::Executed(e) => e.timestamp(),
+            Self::SettlementInitiated(e) => e.timestamp(),
+            Self::SettlementConfirmed(e) => e.timestamp(),
+            Self::SettlementFailed(e) => e.timestamp(),
+        }
+    }
+
+    fn event_type(&self) -> EventType {
+        match self {
+            Self::Executed(e) => e.event_type(),
+            Self::SettlementInitiated(e) => e.event_type(),
+            Self::SettlementConfirmed(e) => e.event_type(),
+            Self::SettlementFailed(e) => e.event_type(),
+        }
+    }
+
+    fn event_name(&self) -> &'static str {
+        match self {
+            Self::Executed(e) => e.event_name(),
+            Self::SettlementInitiated(e) => e.event_name(),
+            Self::SettlementConfirmed(e) => e.event_name(),
+            Self::SettlementFailed(e) => e.event_name(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn test_rfq_id() -> RfqId {
+        RfqId::new_v4()
+    }
+
+    fn test_trade_id() -> TradeId {
+        TradeId::new_v4()
+    }
+
+    fn test_quote_id() -> QuoteId {
+        QuoteId::new_v4()
+    }
+
+    fn test_venue_id() -> VenueId {
+        VenueId::new("test-venue")
+    }
+
+    fn test_counterparty_id() -> CounterpartyId {
+        CounterpartyId::new("test-client")
+    }
+
+    mod trade_executed {
+        use super::*;
+
+        #[test]
+        fn creates_event() {
+            let rfq_id = test_rfq_id();
+            let trade_id = test_trade_id();
+            let event = TradeExecuted::new(
+                rfq_id,
+                trade_id,
+                test_quote_id(),
+                test_venue_id(),
+                test_counterparty_id(),
+                Price::new(50000.0).unwrap(),
+                Quantity::new(1.0).unwrap(),
+                SettlementMethod::OnChain(Blockchain::Ethereum),
+            );
+
+            assert_eq!(event.rfq_id(), Some(rfq_id));
+            assert_eq!(event.trade_id, trade_id);
+            assert_eq!(event.event_name(), "TradeExecuted");
+            assert_eq!(event.event_type(), EventType::Trade);
+        }
+
+        #[test]
+        fn serde_roundtrip() {
+            let event = TradeExecuted::new(
+                test_rfq_id(),
+                test_trade_id(),
+                test_quote_id(),
+                test_venue_id(),
+                test_counterparty_id(),
+                Price::new(50000.0).unwrap(),
+                Quantity::new(1.0).unwrap(),
+                SettlementMethod::OffChain,
+            );
+
+            let json = serde_json::to_string(&event).unwrap();
+            let deserialized: TradeExecuted = serde_json::from_str(&json).unwrap();
+            assert_eq!(event.trade_id, deserialized.trade_id);
+        }
+    }
+
+    mod settlement_initiated {
+        use super::*;
+
+        #[test]
+        fn on_chain() {
+            let event = SettlementInitiated::on_chain(
+                test_rfq_id(),
+                test_trade_id(),
+                Blockchain::Ethereum,
+                "0xabc123".to_string(),
+            );
+
+            assert_eq!(event.tx_hash, Some("0xabc123".to_string()));
+            assert_eq!(
+                event.settlement_method,
+                SettlementMethod::OnChain(Blockchain::Ethereum)
+            );
+            assert_eq!(event.event_name(), "SettlementInitiated");
+            assert_eq!(event.event_type(), EventType::Settlement);
+        }
+
+        #[test]
+        fn off_chain() {
+            let event = SettlementInitiated::off_chain(test_rfq_id(), test_trade_id());
+
+            assert!(event.tx_hash.is_none());
+            assert_eq!(event.settlement_method, SettlementMethod::OffChain);
+        }
+    }
+
+    mod settlement_confirmed {
+        use super::*;
+
+        #[test]
+        fn on_chain() {
+            let event = SettlementConfirmed::on_chain(
+                test_rfq_id(),
+                test_trade_id(),
+                "0xdef456".to_string(),
+                12345678,
+            );
+
+            assert_eq!(event.tx_hash, Some("0xdef456".to_string()));
+            assert_eq!(event.block_number, Some(12345678));
+            assert_eq!(event.event_name(), "SettlementConfirmed");
+        }
+
+        #[test]
+        fn off_chain() {
+            let event = SettlementConfirmed::off_chain(test_rfq_id(), test_trade_id());
+
+            assert!(event.tx_hash.is_none());
+            assert!(event.block_number.is_none());
+        }
+    }
+
+    mod settlement_failed {
+        use super::*;
+
+        #[test]
+        fn creates_event() {
+            let event = SettlementFailed::new(
+                test_rfq_id(),
+                test_trade_id(),
+                "Insufficient funds",
+                Some("0xfailed".to_string()),
+            );
+
+            assert_eq!(event.reason, "Insufficient funds");
+            assert_eq!(event.tx_hash, Some("0xfailed".to_string()));
+            assert_eq!(event.event_name(), "SettlementFailed");
+        }
+    }
+
+    mod trade_event_enum {
+        use super::*;
+
+        #[test]
+        fn serde_roundtrip() {
+            let event = TradeEvent::SettlementConfirmed(SettlementConfirmed::on_chain(
+                test_rfq_id(),
+                test_trade_id(),
+                "0xabc".to_string(),
+                100,
+            ));
+
+            let json = serde_json::to_string(&event).unwrap();
+            let deserialized: TradeEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(event.event_name(), deserialized.event_name());
+        }
+
+        #[test]
+        fn domain_event_trait() {
+            let event = TradeEvent::SettlementFailed(SettlementFailed::new(
+                test_rfq_id(),
+                test_trade_id(),
+                "Error",
+                None,
+            ));
+
+            assert_eq!(event.event_name(), "SettlementFailed");
+            assert_eq!(event.event_type(), EventType::Settlement);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implement domain events for the RFQ lifecycle to support event sourcing and audit trail.

## Changes

### DomainEvent Trait
- `event_id()`: Unique event identifier
- `rfq_id()`: Associated RFQ (if any)
- `timestamp()`: When the event occurred
- `event_type()`: Category (Rfq, Quote, Trade, Settlement, Compliance)
- `event_name()`: Human-readable name

### RFQ Lifecycle Events
| Event | Description |
|-------|-------------|
| `RfqCreated` | New RFQ initiated |
| `QuoteCollectionStarted` | Quote collection begins |
| `QuoteRequested` | Quote requested from venue |
| `QuoteReceived` | Quote received from venue |
| `QuoteRequestFailed` | Quote request failed |
| `QuoteCollectionCompleted` | Quote collection finished |
| `QuoteSelected` | Client selected a quote |
| `ExecutionStarted` | Trade execution begins |
| `ExecutionFailed` | Trade execution failed |
| `RfqCancelled` | RFQ was cancelled |
| `RfqExpired` | RFQ expired |

### Settlement Events
| Event | Description |
|-------|-------------|
| `TradeExecuted` | Trade successfully executed |
| `SettlementInitiated` | Settlement process started |
| `SettlementConfirmed` | Settlement completed |
| `SettlementFailed` | Settlement failed |

### Compliance Events
| Event | Description |
|-------|-------------|
| `ComplianceCheckPassed` | Compliance check passed |
| `ComplianceCheckFailed` | Compliance check failed |

## Technical Decisions

- All events implement `DomainEvent` trait for uniform handling
- `EventMetadata` struct embeds common fields (event_id, rfq_id, timestamp)
- Type-safe enum wrappers (`RfqEvent`, `TradeEvent`, `ComplianceEvent`) for pattern matching
- `ComplianceCheckType` enum for different check types (KYC, AML, Sanctions, etc.)
- All events are `Serialize`/`Deserialize` for persistence

## Testing

- [x] Unit tests added (41 new tests, 413 total)
- [x] Tests cover event creation
- [x] Tests cover DomainEvent trait implementations
- [x] Tests cover serde round-trip

## Checklist

- [x] Code follows `.internalDoc/09-rust-guidelines.md`
- [x] Documentation updated (doc comments on all public items)
- [x] No warnings from `cargo clippy`

Closes #19