### PR TITLE
M2 #31: Define EventStore trait and implement PostgreSQL event store

### DIFF
--- a/src/infrastructure/persistence/event_store.rs
+++ b/src/infrastructure/persistence/event_store.rs
@@ -1,5 +1,316 @@
 //! # Event Store Trait
 //!
-//! Port definition for event store.
+//! Port definition for append-only domain event persistence.
+//!
+//! The event store provides append-only semantics for domain events,
+//! enabling event sourcing patterns and audit trails.
+//!
+//! # Examples
+//!
+//! ```ignore
+//! use otc_rfq::infrastructure::persistence::event_store::{EventStore, StoredEvent};
+//!
+//! // Append an event
+//! event_store.append(&rfq_id, event).await?;
+//!
+//! // Retrieve events for an RFQ
+//! let events = event_store.get_events(&rfq_id).await?;
+//! ```
 
-// TODO: Implement in M2 #31
+use crate::domain::events::domain_event::EventType;
+use crate::domain::value_objects::timestamp::Timestamp;
+use crate::domain::value_objects::{EventId, RfqId};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use thiserror::Error;
+
+/// Error type for event store operations.
+#[derive(Debug, Error)]
+pub enum EventStoreError {
+    /// Failed to serialize event.
+    #[error("serialization error: {0}")]
+    Serialization(String),
+
+    /// Failed to deserialize event.
+    #[error("deserialization error: {0}")]
+    Deserialization(String),
+
+    /// Database connection error.
+    #[error("connection error: {0}")]
+    Connection(String),
+
+    /// Query execution error.
+    #[error("query error: {0}")]
+    Query(String),
+
+    /// Internal error.
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl EventStoreError {
+    /// Creates a serialization error.
+    #[must_use]
+    pub fn serialization(msg: impl Into<String>) -> Self {
+        Self::Serialization(msg.into())
+    }
+
+    /// Creates a deserialization error.
+    #[must_use]
+    pub fn deserialization(msg: impl Into<String>) -> Self {
+        Self::Deserialization(msg.into())
+    }
+
+    /// Creates a connection error.
+    #[must_use]
+    pub fn connection(msg: impl Into<String>) -> Self {
+        Self::Connection(msg.into())
+    }
+
+    /// Creates a query error.
+    #[must_use]
+    pub fn query(msg: impl Into<String>) -> Self {
+        Self::Query(msg.into())
+    }
+
+    /// Creates an internal error.
+    #[must_use]
+    pub fn internal(msg: impl Into<String>) -> Self {
+        Self::Internal(msg.into())
+    }
+}
+
+/// Result type for event store operations.
+pub type EventStoreResult<T> = Result<T, EventStoreError>;
+
+/// A stored domain event with metadata.
+///
+/// This struct wraps the serialized event payload with common metadata
+/// for storage and retrieval.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredEvent {
+    /// Unique identifier for this event.
+    pub event_id: EventId,
+    /// The RFQ this event relates to.
+    pub rfq_id: Option<RfqId>,
+    /// Type/category of the event.
+    pub event_type: EventType,
+    /// Human-readable event name.
+    pub event_name: String,
+    /// When the event occurred.
+    pub timestamp: Timestamp,
+    /// Serialized event payload as JSON.
+    pub payload: serde_json::Value,
+    /// Sequence number for ordering within an aggregate.
+    pub sequence: u64,
+}
+
+impl StoredEvent {
+    /// Creates a new stored event.
+    #[must_use]
+    pub fn new(
+        event_id: EventId,
+        rfq_id: Option<RfqId>,
+        event_type: EventType,
+        event_name: impl Into<String>,
+        timestamp: Timestamp,
+        payload: serde_json::Value,
+        sequence: u64,
+    ) -> Self {
+        Self {
+            event_id,
+            rfq_id,
+            event_type,
+            event_name: event_name.into(),
+            timestamp,
+            payload,
+            sequence,
+        }
+    }
+
+    /// Creates a stored event from a domain event.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the event cannot be serialized.
+    pub fn from_event<E: Serialize + crate::domain::events::domain_event::DomainEvent>(
+        event: &E,
+        sequence: u64,
+    ) -> EventStoreResult<Self> {
+        let payload = serde_json::to_value(event)
+            .map_err(|e| EventStoreError::serialization(e.to_string()))?;
+
+        Ok(Self {
+            event_id: event.event_id(),
+            rfq_id: event.rfq_id(),
+            event_type: event.event_type(),
+            event_name: event.event_name().to_string(),
+            timestamp: event.timestamp(),
+            payload,
+            sequence,
+        })
+    }
+}
+
+impl fmt::Display for StoredEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}[{}] at {}",
+            self.event_name, self.event_id, self.timestamp
+        )
+    }
+}
+
+/// Trait for append-only event storage.
+///
+/// The event store provides append-only semantics - events can only be
+/// added, never modified or deleted. This ensures a complete audit trail
+/// and enables event sourcing patterns.
+///
+/// # Thread Safety
+///
+/// Implementations must be `Send + Sync` for use in async contexts.
+#[async_trait]
+pub trait EventStore: Send + Sync + fmt::Debug {
+    /// Appends an event to the store.
+    ///
+    /// # Arguments
+    ///
+    /// * `event` - The stored event to append
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the event cannot be stored.
+    async fn append(&self, event: StoredEvent) -> EventStoreResult<()>;
+
+    /// Retrieves all events for an RFQ.
+    ///
+    /// Events are returned in sequence order (oldest first).
+    ///
+    /// # Arguments
+    ///
+    /// * `rfq_id` - The RFQ to get events for
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if events cannot be retrieved.
+    async fn get_events(&self, rfq_id: &RfqId) -> EventStoreResult<Vec<StoredEvent>>;
+
+    /// Retrieves all events since a given timestamp.
+    ///
+    /// Events are returned in timestamp order (oldest first).
+    ///
+    /// # Arguments
+    ///
+    /// * `since` - Only return events after this timestamp
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if events cannot be retrieved.
+    async fn get_events_since(&self, since: Timestamp) -> EventStoreResult<Vec<StoredEvent>>;
+
+    /// Retrieves all events of a specific type.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - The type of events to retrieve
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if events cannot be retrieved.
+    async fn get_events_by_type(&self, event_type: EventType)
+        -> EventStoreResult<Vec<StoredEvent>>;
+
+    /// Returns the total number of events in the store.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the count cannot be retrieved.
+    async fn count(&self) -> EventStoreResult<u64>;
+
+    /// Returns the number of events for an RFQ.
+    ///
+    /// # Arguments
+    ///
+    /// * `rfq_id` - The RFQ to count events for
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the count cannot be retrieved.
+    async fn count_for_rfq(&self, rfq_id: &RfqId) -> EventStoreResult<u64>;
+
+    /// Returns the next sequence number for an RFQ.
+    ///
+    /// # Arguments
+    ///
+    /// * `rfq_id` - The RFQ to get the next sequence for
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the sequence cannot be determined.
+    async fn next_sequence(&self, rfq_id: &RfqId) -> EventStoreResult<u64>;
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_store_error_display() {
+        let err = EventStoreError::serialization("test error");
+        assert_eq!(err.to_string(), "serialization error: test error");
+
+        let err = EventStoreError::deserialization("test error");
+        assert_eq!(err.to_string(), "deserialization error: test error");
+
+        let err = EventStoreError::connection("test error");
+        assert_eq!(err.to_string(), "connection error: test error");
+
+        let err = EventStoreError::query("test error");
+        assert_eq!(err.to_string(), "query error: test error");
+
+        let err = EventStoreError::internal("test error");
+        assert_eq!(err.to_string(), "internal error: test error");
+    }
+
+    #[test]
+    fn stored_event_display() {
+        let event = StoredEvent::new(
+            EventId::new_v4(),
+            Some(RfqId::new_v4()),
+            EventType::Rfq,
+            "RfqCreated",
+            Timestamp::now(),
+            serde_json::json!({}),
+            1,
+        );
+
+        let display = event.to_string();
+        assert!(display.contains("RfqCreated"));
+    }
+
+    #[test]
+    fn stored_event_serde_roundtrip() {
+        let event = StoredEvent::new(
+            EventId::new_v4(),
+            Some(RfqId::new_v4()),
+            EventType::Rfq,
+            "RfqCreated",
+            Timestamp::now(),
+            serde_json::json!({"test": "data"}),
+            1,
+        );
+
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: StoredEvent = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(event.event_id, deserialized.event_id);
+        assert_eq!(event.rfq_id, deserialized.rfq_id);
+        assert_eq!(event.event_type, deserialized.event_type);
+        assert_eq!(event.event_name, deserialized.event_name);
+        assert_eq!(event.sequence, deserialized.sequence);
+    }
+}

--- a/src/infrastructure/persistence/mod.rs
+++ b/src/infrastructure/persistence/mod.rs
@@ -8,18 +8,19 @@
 //! - [`TradeRepository`]: Persistence for Trade entities
 //! - [`VenueRepository`]: Persistence for venue configurations
 //! - [`CounterpartyRepository`]: Persistence for counterparty data
+//! - [`EventStore`]: Append-only event storage
 //!
 //! ## Implementations
 //!
 //! - `in_memory`: In-memory implementations for testing
-//! - `postgres`: PostgreSQL implementations (TODO)
-//! - `event_store`: Event sourcing support (TODO)
+//! - `postgres`: PostgreSQL implementations with sqlx
 
 pub mod event_store;
 pub mod in_memory;
 pub mod postgres;
 pub mod traits;
 
+pub use event_store::{EventStore, EventStoreError, EventStoreResult, StoredEvent};
 pub use traits::{
     CounterpartyRepository, RepositoryError, RepositoryResult, RfqRepository, TradeRepository,
     VenueRepository,

--- a/src/infrastructure/persistence/postgres/event_store.rs
+++ b/src/infrastructure/persistence/postgres/event_store.rs
@@ -1,5 +1,235 @@
 //! # PostgreSQL Event Store
 //!
-//! PostgreSQL implementation of event store.
+//! PostgreSQL implementation of [`EventStore`] using sqlx.
+//!
+//! This implementation provides append-only event storage with JSONB
+//! serialization for event payloads.
 
-// TODO: Implement in M2 #31
+use crate::domain::events::domain_event::EventType;
+use crate::domain::value_objects::timestamp::Timestamp;
+use crate::domain::value_objects::{EventId, RfqId};
+use crate::infrastructure::persistence::event_store::{
+    EventStore, EventStoreError, EventStoreResult, StoredEvent,
+};
+use async_trait::async_trait;
+use sqlx::PgPool;
+
+/// PostgreSQL implementation of [`EventStore`].
+///
+/// Uses connection pooling via `sqlx::PgPool` and JSONB for event payloads.
+/// Provides append-only semantics - events can only be inserted, never
+/// updated or deleted.
+///
+/// # Examples
+///
+/// ```ignore
+/// use sqlx::PgPool;
+/// use otc_rfq::infrastructure::persistence::postgres::PostgresEventStore;
+///
+/// let pool = PgPool::connect("postgres://...").await?;
+/// let store = PostgresEventStore::new(pool);
+/// ```
+#[derive(Debug, Clone)]
+pub struct PostgresEventStore {
+    pool: PgPool,
+}
+
+impl PostgresEventStore {
+    /// Creates a new PostgreSQL event store.
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Returns a reference to the connection pool.
+    #[must_use]
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+#[async_trait]
+impl EventStore for PostgresEventStore {
+    async fn append(&self, event: StoredEvent) -> EventStoreResult<()> {
+        let event_id = event.event_id.to_string();
+        let rfq_id = event.rfq_id.map(|id| id.to_string());
+        let event_type = event.event_type.to_string();
+        let event_name = &event.event_name;
+        let timestamp = event.timestamp.timestamp_millis();
+        let payload = &event.payload;
+        let sequence = event.sequence as i64;
+
+        sqlx::query(
+            r#"
+            INSERT INTO domain_events (
+                event_id, rfq_id, event_type, event_name,
+                timestamp, payload, sequence
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            "#,
+        )
+        .bind(&event_id)
+        .bind(&rfq_id)
+        .bind(&event_type)
+        .bind(event_name)
+        .bind(timestamp)
+        .bind(payload)
+        .bind(sequence)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| EventStoreError::query(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get_events(&self, rfq_id: &RfqId) -> EventStoreResult<Vec<StoredEvent>> {
+        let rfq_id_str = rfq_id.to_string();
+
+        let rows: Vec<EventRow> = sqlx::query_as(
+            r#"
+            SELECT event_id, rfq_id, event_type, event_name,
+                   timestamp, payload, sequence
+            FROM domain_events
+            WHERE rfq_id = $1
+            ORDER BY sequence ASC
+            "#,
+        )
+        .bind(&rfq_id_str)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| EventStoreError::query(e.to_string()))?;
+
+        rows.into_iter()
+            .map(|r| r.try_into_stored_event())
+            .collect()
+    }
+
+    async fn get_events_since(&self, since: Timestamp) -> EventStoreResult<Vec<StoredEvent>> {
+        let since_millis = since.timestamp_millis();
+
+        let rows: Vec<EventRow> = sqlx::query_as(
+            r#"
+            SELECT event_id, rfq_id, event_type, event_name,
+                   timestamp, payload, sequence
+            FROM domain_events
+            WHERE timestamp > $1
+            ORDER BY timestamp ASC, sequence ASC
+            "#,
+        )
+        .bind(since_millis)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| EventStoreError::query(e.to_string()))?;
+
+        rows.into_iter()
+            .map(|r| r.try_into_stored_event())
+            .collect()
+    }
+
+    async fn get_events_by_type(
+        &self,
+        event_type: EventType,
+    ) -> EventStoreResult<Vec<StoredEvent>> {
+        let event_type_str = event_type.to_string();
+
+        let rows: Vec<EventRow> = sqlx::query_as(
+            r#"
+            SELECT event_id, rfq_id, event_type, event_name,
+                   timestamp, payload, sequence
+            FROM domain_events
+            WHERE event_type = $1
+            ORDER BY timestamp ASC, sequence ASC
+            "#,
+        )
+        .bind(&event_type_str)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| EventStoreError::query(e.to_string()))?;
+
+        rows.into_iter()
+            .map(|r| r.try_into_stored_event())
+            .collect()
+    }
+
+    async fn count(&self) -> EventStoreResult<u64> {
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM domain_events")
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| EventStoreError::query(e.to_string()))?;
+
+        Ok(count as u64)
+    }
+
+    async fn count_for_rfq(&self, rfq_id: &RfqId) -> EventStoreResult<u64> {
+        let rfq_id_str = rfq_id.to_string();
+
+        let (count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM domain_events WHERE rfq_id = $1")
+                .bind(&rfq_id_str)
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| EventStoreError::query(e.to_string()))?;
+
+        Ok(count as u64)
+    }
+
+    async fn next_sequence(&self, rfq_id: &RfqId) -> EventStoreResult<u64> {
+        let rfq_id_str = rfq_id.to_string();
+
+        let result: Option<(i64,)> =
+            sqlx::query_as("SELECT MAX(sequence) FROM domain_events WHERE rfq_id = $1")
+                .bind(&rfq_id_str)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| EventStoreError::query(e.to_string()))?;
+
+        match result {
+            Some((max_seq,)) => Ok((max_seq + 1) as u64),
+            None => Ok(1),
+        }
+    }
+}
+
+/// Row type for event queries.
+#[derive(Debug, sqlx::FromRow)]
+struct EventRow {
+    event_id: String,
+    rfq_id: Option<String>,
+    event_type: String,
+    event_name: String,
+    timestamp: i64,
+    payload: serde_json::Value,
+    sequence: i64,
+}
+
+impl EventRow {
+    /// Converts the row into a StoredEvent.
+    fn try_into_stored_event(self) -> EventStoreResult<StoredEvent> {
+        use uuid::Uuid;
+
+        let event_uuid = Uuid::parse_str(&self.event_id)
+            .map_err(|e| EventStoreError::deserialization(e.to_string()))?;
+        let event_id = EventId::new(event_uuid);
+
+        let rfq_id = self
+            .rfq_id
+            .map(|s| Uuid::parse_str(&s).map(RfqId::new))
+            .transpose()
+            .map_err(|e| EventStoreError::deserialization(e.to_string()))?;
+
+        let event_type: EventType = serde_json::from_str(&format!("\"{}\"", self.event_type))
+            .map_err(|e| EventStoreError::deserialization(e.to_string()))?;
+
+        let timestamp = Timestamp::from_millis(self.timestamp)
+            .ok_or_else(|| EventStoreError::deserialization("invalid timestamp".to_string()))?;
+
+        Ok(StoredEvent {
+            event_id,
+            rfq_id,
+            event_type,
+            event_name: self.event_name,
+            timestamp,
+            payload: self.payload,
+            sequence: self.sequence as u64,
+        })
+    }
+}

--- a/src/infrastructure/persistence/postgres/mod.rs
+++ b/src/infrastructure/persistence/postgres/mod.rs
@@ -8,12 +8,14 @@
 //! - [`PostgresTradeRepository`]: Trade persistence with optimistic locking
 //! - [`PostgresVenueRepository`]: Venue configuration persistence
 //! - [`PostgresCounterpartyRepository`]: Counterparty persistence
+//! - [`PostgresEventStore`]: Append-only event storage
 //!
 //! ## Features
 //!
 //! - Connection pooling via `sqlx::PgPool`
 //! - Optimistic locking with version fields
 //! - JSONB serialization for complex fields
+//! - Append-only event store for event sourcing
 
 pub mod counterparty_repository;
 pub mod event_store;
@@ -22,6 +24,7 @@ pub mod trade_repository;
 pub mod venue_repository;
 
 pub use counterparty_repository::PostgresCounterpartyRepository;
+pub use event_store::PostgresEventStore;
 pub use rfq_repository::PostgresRfqRepository;
 pub use trade_repository::PostgresTradeRepository;
 pub use venue_repository::PostgresVenueRepository;


### PR DESCRIPTION
## Summary

Define EventStore trait for append-only domain event persistence and implement PostgreSQL event store.

## Changes

### EventStore Trait
| Method | Description |
|--------|-------------|
| `append()` | Store a new event (append-only, no updates/deletes) |
| `get_events()` | Retrieve all events for an RFQ |
| `get_events_since()` | Retrieve events after a timestamp |
| `get_events_by_type()` | Retrieve events by type |
| `count()` | Total event count |
| `count_for_rfq()` | Event count for an RFQ |
| `next_sequence()` | Get next sequence number for an RFQ |

### StoredEvent Struct
| Field | Description |
|-------|-------------|
| `event_id` | Unique event identifier |
| `rfq_id` | Optional RFQ reference |
| `event_type` | Event category (Rfq, Quote, Trade, etc.) |
| `event_name` | Human-readable event name |
| `timestamp` | When the event occurred |
| `payload` | JSONB serialized event data |
| `sequence` | Ordering within an aggregate |

### PostgresEventStore
- Uses `sqlx::PgPool` for connection pooling
- JSONB serialization for event payloads
- Timestamps stored as milliseconds (i64)
- Append-only semantics (INSERT only)
- Sequence numbers for event ordering

## Technical Decisions

- **Append-only**: Events can only be inserted, never updated or deleted
- **JSONB payload**: Event data stored as JSONB for flexibility
- **Sequence numbers**: Enable ordering within an aggregate
- **Timestamps as i64**: Milliseconds for precision and compatibility

## Testing

- [x] Unit tests added (3 new tests, 617 total)
- [x] No clippy warnings
- [ ] Integration tests require PostgreSQL database

## Checklist

- [x] Code follows `.internalDoc/09-rust-guidelines.md`
- [x] Documentation updated (doc comments on all public items)
- [x] No warnings from `cargo clippy`

Closes #31