### PR TITLE
M2 #34: Implement token mapping and chain configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ futures = { workspace = true }
 parking_lot = { workspace = true }
 dashmap = { workspace = true }
 bytes = { workspace = true }
+toml = "0.9.11"
 
 # IronFix for FIX protocol (optional - enable when available)
 # ironfix = { workspace = true }

--- a/src/infrastructure/blockchain/config.rs
+++ b/src/infrastructure/blockchain/config.rs
@@ -1,5 +1,511 @@
 //! # Chain Configuration
 //!
-//! Configuration for blockchain networks.
+//! Configuration for blockchain networks and multi-chain support.
+//!
+//! Provides chain-specific configuration including RPC URLs, gas strategies,
+//! and network parameters for Ethereum and L2 networks.
 
-// TODO: Implement in M2 #34
+use super::client::ChainId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt;
+use thiserror::Error;
+
+/// Gas price strategy for a chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum GasPriceStrategy {
+    /// Legacy gas pricing (single gas price).
+    Legacy,
+    /// EIP-1559 dynamic fee pricing.
+    #[default]
+    Eip1559,
+}
+
+impl fmt::Display for GasPriceStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Legacy => write!(f, "legacy"),
+            Self::Eip1559 => write!(f, "eip1559"),
+        }
+    }
+}
+
+/// Configuration error.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// Chain not found in configuration.
+    #[error("chain not found: {0}")]
+    ChainNotFound(String),
+
+    /// Invalid configuration value.
+    #[error("invalid configuration: {0}")]
+    Invalid(String),
+
+    /// Missing required field.
+    #[error("missing required field: {0}")]
+    MissingField(String),
+
+    /// Environment variable not set.
+    #[error("environment variable not set: {0}")]
+    EnvVarNotSet(String),
+
+    /// TOML parsing error.
+    #[error("TOML parse error: {0}")]
+    TomlParse(String),
+}
+
+/// Result type for configuration operations.
+pub type ConfigResult<T> = Result<T, ConfigError>;
+
+/// Configuration for a single blockchain network.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChainConfig {
+    /// Chain identifier.
+    pub chain_id: ChainId,
+    /// RPC endpoint URLs (primary first, then backups).
+    pub rpc_urls: Vec<String>,
+    /// Average block time in milliseconds.
+    pub block_time_ms: u64,
+    /// Gas price strategy for this chain.
+    pub gas_price_strategy: GasPriceStrategy,
+    /// Required confirmations for transaction finality.
+    #[serde(default = "default_confirmations")]
+    pub confirmations: u64,
+    /// Gas buffer percentage for estimation.
+    #[serde(default = "default_gas_buffer")]
+    pub gas_buffer_percent: u64,
+}
+
+fn default_confirmations() -> u64 {
+    1
+}
+
+fn default_gas_buffer() -> u64 {
+    20
+}
+
+impl ChainConfig {
+    /// Creates a new chain configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `chain_id` - The chain identifier
+    /// * `rpc_urls` - RPC endpoint URLs
+    #[must_use]
+    pub fn new(chain_id: ChainId, rpc_urls: Vec<String>) -> Self {
+        Self {
+            chain_id,
+            rpc_urls,
+            block_time_ms: chain_id.block_time_ms(),
+            gas_price_strategy: if chain_id.supports_eip1559() {
+                GasPriceStrategy::Eip1559
+            } else {
+                GasPriceStrategy::Legacy
+            },
+            confirmations: default_confirmations(),
+            gas_buffer_percent: default_gas_buffer(),
+        }
+    }
+
+    /// Returns the primary RPC URL.
+    #[must_use]
+    pub fn primary_rpc(&self) -> Option<&str> {
+        self.rpc_urls.first().map(String::as_str)
+    }
+
+    /// Returns backup RPC URLs.
+    #[must_use]
+    pub fn backup_rpcs(&self) -> Vec<String> {
+        self.rpc_urls.iter().skip(1).cloned().collect()
+    }
+
+    /// Validates the configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the configuration is invalid.
+    pub fn validate(&self) -> ConfigResult<()> {
+        if self.rpc_urls.is_empty() {
+            return Err(ConfigError::MissingField("rpc_urls".to_string()));
+        }
+
+        if self.block_time_ms == 0 {
+            return Err(ConfigError::Invalid(
+                "block_time_ms must be greater than 0".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// Builder for chain configuration.
+#[derive(Debug, Default)]
+pub struct ChainConfigBuilder {
+    chain_id: Option<ChainId>,
+    rpc_urls: Vec<String>,
+    block_time_ms: Option<u64>,
+    gas_price_strategy: Option<GasPriceStrategy>,
+    confirmations: Option<u64>,
+    gas_buffer_percent: Option<u64>,
+}
+
+impl ChainConfigBuilder {
+    /// Creates a new builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the chain ID.
+    #[must_use]
+    pub fn chain_id(mut self, chain_id: ChainId) -> Self {
+        self.chain_id = Some(chain_id);
+        self
+    }
+
+    /// Adds an RPC URL.
+    #[must_use]
+    pub fn rpc_url(mut self, url: impl Into<String>) -> Self {
+        self.rpc_urls.push(url.into());
+        self
+    }
+
+    /// Sets multiple RPC URLs.
+    #[must_use]
+    pub fn rpc_urls(mut self, urls: Vec<String>) -> Self {
+        self.rpc_urls = urls;
+        self
+    }
+
+    /// Sets the block time in milliseconds.
+    #[must_use]
+    pub fn block_time_ms(mut self, ms: u64) -> Self {
+        self.block_time_ms = Some(ms);
+        self
+    }
+
+    /// Sets the gas price strategy.
+    #[must_use]
+    pub fn gas_price_strategy(mut self, strategy: GasPriceStrategy) -> Self {
+        self.gas_price_strategy = Some(strategy);
+        self
+    }
+
+    /// Sets the required confirmations.
+    #[must_use]
+    pub fn confirmations(mut self, confirmations: u64) -> Self {
+        self.confirmations = Some(confirmations);
+        self
+    }
+
+    /// Sets the gas buffer percentage.
+    #[must_use]
+    pub fn gas_buffer_percent(mut self, percent: u64) -> Self {
+        self.gas_buffer_percent = Some(percent);
+        self
+    }
+
+    /// Builds the chain configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if required fields are missing.
+    pub fn build(self) -> ConfigResult<ChainConfig> {
+        let chain_id = self
+            .chain_id
+            .ok_or_else(|| ConfigError::MissingField("chain_id".to_string()))?;
+
+        if self.rpc_urls.is_empty() {
+            return Err(ConfigError::MissingField("rpc_urls".to_string()));
+        }
+
+        Ok(ChainConfig {
+            chain_id,
+            rpc_urls: self.rpc_urls,
+            block_time_ms: self
+                .block_time_ms
+                .unwrap_or_else(|| chain_id.block_time_ms()),
+            gas_price_strategy: self.gas_price_strategy.unwrap_or_else(|| {
+                if chain_id.supports_eip1559() {
+                    GasPriceStrategy::Eip1559
+                } else {
+                    GasPriceStrategy::Legacy
+                }
+            }),
+            confirmations: self.confirmations.unwrap_or_else(default_confirmations),
+            gas_buffer_percent: self.gas_buffer_percent.unwrap_or_else(default_gas_buffer),
+        })
+    }
+}
+
+/// Multi-chain configuration container.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ChainsConfig {
+    /// Chain configurations indexed by chain name.
+    #[serde(flatten)]
+    pub chains: HashMap<String, ChainConfig>,
+}
+
+impl ChainsConfig {
+    /// Creates a new empty chains configuration.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a chain configuration.
+    pub fn add_chain(&mut self, name: impl Into<String>, config: ChainConfig) {
+        self.chains.insert(name.into(), config);
+    }
+
+    /// Gets a chain configuration by name.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&ChainConfig> {
+        self.chains.get(name)
+    }
+
+    /// Gets a chain configuration by chain ID.
+    #[must_use]
+    pub fn get_by_chain_id(&self, chain_id: ChainId) -> Option<&ChainConfig> {
+        self.chains.values().find(|c| c.chain_id == chain_id)
+    }
+
+    /// Returns all chain names.
+    #[must_use]
+    pub fn chain_names(&self) -> Vec<&str> {
+        self.chains.keys().map(String::as_str).collect()
+    }
+
+    /// Returns the number of configured chains.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.chains.len()
+    }
+
+    /// Returns true if no chains are configured.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.chains.is_empty()
+    }
+
+    /// Validates all chain configurations.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any configuration is invalid.
+    pub fn validate(&self) -> ConfigResult<()> {
+        for (name, config) in &self.chains {
+            config
+                .validate()
+                .map_err(|e| ConfigError::Invalid(format!("chain '{}': {}", name, e)))?;
+        }
+        Ok(())
+    }
+}
+
+/// Substitutes environment variables in a string.
+///
+/// Replaces `${VAR_NAME}` patterns with the corresponding environment variable value.
+///
+/// # Arguments
+///
+/// * `input` - The input string with potential variable references
+///
+/// # Errors
+///
+/// Returns an error if a referenced environment variable is not set.
+pub fn substitute_env_vars(input: &str) -> ConfigResult<String> {
+    let mut result = input.to_string();
+    let mut start = 0;
+
+    while let Some(var_start) = result[start..].find("${") {
+        let abs_start = start + var_start;
+        if let Some(var_end) = result[abs_start..].find('}') {
+            let abs_end = abs_start + var_end;
+            let var_name = &result[abs_start + 2..abs_end];
+
+            let var_value = std::env::var(var_name)
+                .map_err(|_| ConfigError::EnvVarNotSet(var_name.to_string()))?;
+
+            result.replace_range(abs_start..abs_end + 1, &var_value);
+            start = abs_start + var_value.len();
+        } else {
+            break;
+        }
+    }
+
+    Ok(result)
+}
+
+/// Parses a TOML configuration string into chains configuration.
+///
+/// # Arguments
+///
+/// * `toml_str` - The TOML configuration string
+///
+/// # Errors
+///
+/// Returns an error if parsing fails.
+pub fn parse_chains_config(toml_str: &str) -> ConfigResult<ChainsConfig> {
+    toml::from_str(toml_str).map_err(|e| ConfigError::TomlParse(e.to_string()))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gas_price_strategy_display() {
+        assert_eq!(GasPriceStrategy::Legacy.to_string(), "legacy");
+        assert_eq!(GasPriceStrategy::Eip1559.to_string(), "eip1559");
+    }
+
+    #[test]
+    fn chain_config_new() {
+        let config = ChainConfig::new(
+            ChainId::Ethereum,
+            vec!["https://eth.example.com".to_string()],
+        );
+
+        assert_eq!(config.chain_id, ChainId::Ethereum);
+        assert_eq!(config.rpc_urls.len(), 1);
+        assert_eq!(config.block_time_ms, 12000);
+        assert_eq!(config.gas_price_strategy, GasPriceStrategy::Eip1559);
+        assert_eq!(config.confirmations, 1);
+        assert_eq!(config.gas_buffer_percent, 20);
+    }
+
+    #[test]
+    fn chain_config_arbitrum_uses_legacy() {
+        let config = ChainConfig::new(
+            ChainId::Arbitrum,
+            vec!["https://arb.example.com".to_string()],
+        );
+
+        assert_eq!(config.gas_price_strategy, GasPriceStrategy::Legacy);
+    }
+
+    #[test]
+    fn chain_config_primary_and_backup_rpcs() {
+        let config = ChainConfig::new(
+            ChainId::Ethereum,
+            vec![
+                "https://primary.example.com".to_string(),
+                "https://backup1.example.com".to_string(),
+                "https://backup2.example.com".to_string(),
+            ],
+        );
+
+        assert_eq!(config.primary_rpc(), Some("https://primary.example.com"));
+        assert_eq!(config.backup_rpcs().len(), 2);
+    }
+
+    #[test]
+    fn chain_config_validate_success() {
+        let config = ChainConfig::new(
+            ChainId::Ethereum,
+            vec!["https://eth.example.com".to_string()],
+        );
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn chain_config_validate_empty_rpc() {
+        let config = ChainConfig {
+            chain_id: ChainId::Ethereum,
+            rpc_urls: vec![],
+            block_time_ms: 12000,
+            gas_price_strategy: GasPriceStrategy::Eip1559,
+            confirmations: 1,
+            gas_buffer_percent: 20,
+        };
+
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn chain_config_builder() {
+        let config = ChainConfigBuilder::new()
+            .chain_id(ChainId::Polygon)
+            .rpc_url("https://polygon.example.com")
+            .confirmations(5)
+            .gas_buffer_percent(25)
+            .build()
+            .unwrap();
+
+        assert_eq!(config.chain_id, ChainId::Polygon);
+        assert_eq!(config.confirmations, 5);
+        assert_eq!(config.gas_buffer_percent, 25);
+    }
+
+    #[test]
+    fn chain_config_builder_missing_chain_id() {
+        let result = ChainConfigBuilder::new()
+            .rpc_url("https://example.com")
+            .build();
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn chains_config_add_and_get() {
+        let mut config = ChainsConfig::new();
+        config.add_chain(
+            "ethereum",
+            ChainConfig::new(
+                ChainId::Ethereum,
+                vec!["https://eth.example.com".to_string()],
+            ),
+        );
+
+        assert_eq!(config.len(), 1);
+        assert!(config.get("ethereum").is_some());
+        assert!(config.get("polygon").is_none());
+    }
+
+    #[test]
+    fn chains_config_get_by_chain_id() {
+        let mut config = ChainsConfig::new();
+        config.add_chain(
+            "ethereum",
+            ChainConfig::new(
+                ChainId::Ethereum,
+                vec!["https://eth.example.com".to_string()],
+            ),
+        );
+
+        assert!(config.get_by_chain_id(ChainId::Ethereum).is_some());
+        assert!(config.get_by_chain_id(ChainId::Polygon).is_none());
+    }
+
+    #[test]
+    fn substitute_env_vars_no_vars() {
+        let result = substitute_env_vars("https://example.com").unwrap();
+        assert_eq!(result, "https://example.com");
+    }
+
+    #[test]
+    fn substitute_env_vars_with_var() {
+        std::env::set_var("TEST_API_KEY", "secret123");
+        let result = substitute_env_vars("https://api.example.com/v1/${TEST_API_KEY}").unwrap();
+        assert_eq!(result, "https://api.example.com/v1/secret123");
+        std::env::remove_var("TEST_API_KEY");
+    }
+
+    #[test]
+    fn substitute_env_vars_missing_var() {
+        std::env::remove_var("NONEXISTENT_VAR");
+        let result = substitute_env_vars("https://api.example.com/${NONEXISTENT_VAR}");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn config_error_display() {
+        let err = ConfigError::ChainNotFound("unknown".to_string());
+        assert_eq!(err.to_string(), "chain not found: unknown");
+    }
+}

--- a/src/infrastructure/blockchain/mod.rs
+++ b/src/infrastructure/blockchain/mod.rs
@@ -9,6 +9,8 @@
 //! - [`GasPrice`]: Gas pricing (legacy and EIP-1559)
 //! - [`GasEstimator`]: Gas estimation with buffer
 //! - [`ChainId`]: Supported blockchain networks
+//! - [`ChainConfig`]: Chain-specific configuration
+//! - [`TokenRegistry`]: Token address mapping across chains
 //!
 //! ## Supported Chains
 //!
@@ -27,5 +29,12 @@ pub mod tokens;
 pub use client::{
     BlockchainClient, BlockchainError, BlockchainResult, ChainId, TxHash, TxPriority, TxReceipt,
 };
+pub use config::{
+    parse_chains_config, substitute_env_vars, ChainConfig, ChainConfigBuilder, ChainsConfig,
+    ConfigError, ConfigResult, GasPriceStrategy,
+};
 pub use ethereum::EthereumClient;
 pub use gas::{FeeHistory, GasEstimator, GasPrice};
+pub use tokens::{
+    is_valid_address, normalize_address, TokenError, TokenInfo, TokenRegistry, TokenResult,
+};

--- a/src/infrastructure/blockchain/tokens.rs
+++ b/src/infrastructure/blockchain/tokens.rs
@@ -1,5 +1,484 @@
 //! # Token Registry
 //!
 //! Token address mapping across chains.
+//!
+//! Provides a registry for looking up token addresses by symbol and chain,
+//! supporting multi-chain deployments of the same token.
 
-// TODO: Implement in M2 #34
+use super::client::ChainId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use thiserror::Error;
+
+/// Token registry error.
+#[derive(Debug, Error)]
+pub enum TokenError {
+    /// Token not found in registry.
+    #[error("token not found: {0}")]
+    TokenNotFound(String),
+
+    /// Token not available on specified chain.
+    #[error("token '{0}' not available on chain {1}")]
+    NotOnChain(String, ChainId),
+
+    /// Invalid token address format.
+    #[error("invalid address format: {0}")]
+    InvalidAddress(String),
+}
+
+/// Result type for token operations.
+pub type TokenResult<T> = Result<T, TokenError>;
+
+/// Information about a token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenInfo {
+    /// Token symbol (e.g., "WETH", "USDC").
+    pub symbol: String,
+    /// Token name (e.g., "Wrapped Ether").
+    pub name: String,
+    /// Token decimals.
+    pub decimals: u8,
+    /// Token addresses per chain.
+    #[serde(default)]
+    pub addresses: HashMap<ChainId, String>,
+}
+
+impl TokenInfo {
+    /// Creates a new token info.
+    #[must_use]
+    pub fn new(symbol: impl Into<String>, name: impl Into<String>, decimals: u8) -> Self {
+        Self {
+            symbol: symbol.into(),
+            name: name.into(),
+            decimals,
+            addresses: HashMap::new(),
+        }
+    }
+
+    /// Adds an address for a chain.
+    #[must_use]
+    pub fn with_address(mut self, chain: ChainId, address: impl Into<String>) -> Self {
+        self.addresses.insert(chain, address.into());
+        self
+    }
+
+    /// Gets the address for a specific chain.
+    #[must_use]
+    pub fn address(&self, chain: ChainId) -> Option<&str> {
+        self.addresses.get(&chain).map(String::as_str)
+    }
+
+    /// Returns all chains where this token is available.
+    #[must_use]
+    pub fn available_chains(&self) -> Vec<ChainId> {
+        self.addresses.keys().copied().collect()
+    }
+
+    /// Returns true if the token is available on the specified chain.
+    #[must_use]
+    pub fn is_available_on(&self, chain: ChainId) -> bool {
+        self.addresses.contains_key(&chain)
+    }
+}
+
+/// Registry for token address mappings across chains.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TokenRegistry {
+    /// Tokens indexed by symbol.
+    #[serde(flatten)]
+    tokens: HashMap<String, TokenInfo>,
+}
+
+impl TokenRegistry {
+    /// Creates a new empty token registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a registry with common tokens pre-populated.
+    #[must_use]
+    pub fn with_common_tokens() -> Self {
+        let mut registry = Self::new();
+
+        // WETH
+        registry.register(
+            TokenInfo::new("WETH", "Wrapped Ether", 18)
+                .with_address(
+                    ChainId::Ethereum,
+                    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                )
+                .with_address(
+                    ChainId::Arbitrum,
+                    "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+                )
+                .with_address(
+                    ChainId::Polygon,
+                    "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+                )
+                .with_address(
+                    ChainId::Optimism,
+                    "0x4200000000000000000000000000000000000006",
+                )
+                .with_address(ChainId::Base, "0x4200000000000000000000000000000000000006"),
+        );
+
+        // USDC
+        registry.register(
+            TokenInfo::new("USDC", "USD Coin", 6)
+                .with_address(
+                    ChainId::Ethereum,
+                    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                )
+                .with_address(
+                    ChainId::Arbitrum,
+                    "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+                )
+                .with_address(
+                    ChainId::Polygon,
+                    "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+                )
+                .with_address(
+                    ChainId::Optimism,
+                    "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+                )
+                .with_address(ChainId::Base, "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"),
+        );
+
+        // USDT
+        registry.register(
+            TokenInfo::new("USDT", "Tether USD", 6)
+                .with_address(
+                    ChainId::Ethereum,
+                    "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                )
+                .with_address(
+                    ChainId::Arbitrum,
+                    "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+                )
+                .with_address(
+                    ChainId::Polygon,
+                    "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+                )
+                .with_address(
+                    ChainId::Optimism,
+                    "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+                ),
+        );
+
+        // DAI
+        registry.register(
+            TokenInfo::new("DAI", "Dai Stablecoin", 18)
+                .with_address(
+                    ChainId::Ethereum,
+                    "0x6B175474E89094C44Da98b954EeddeBC35e4D1",
+                )
+                .with_address(
+                    ChainId::Arbitrum,
+                    "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+                )
+                .with_address(
+                    ChainId::Polygon,
+                    "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+                )
+                .with_address(
+                    ChainId::Optimism,
+                    "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+                )
+                .with_address(ChainId::Base, "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"),
+        );
+
+        // WBTC
+        registry.register(
+            TokenInfo::new("WBTC", "Wrapped Bitcoin", 8)
+                .with_address(
+                    ChainId::Ethereum,
+                    "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+                )
+                .with_address(
+                    ChainId::Arbitrum,
+                    "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+                )
+                .with_address(
+                    ChainId::Polygon,
+                    "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
+                )
+                .with_address(
+                    ChainId::Optimism,
+                    "0x68f180fcCe6836688e9084f035309E29Bf0A2095",
+                ),
+        );
+
+        registry
+    }
+
+    /// Registers a token in the registry.
+    pub fn register(&mut self, token: TokenInfo) {
+        self.tokens.insert(token.symbol.clone(), token);
+    }
+
+    /// Gets token info by symbol.
+    #[must_use]
+    pub fn get(&self, symbol: &str) -> Option<&TokenInfo> {
+        self.tokens.get(symbol)
+    }
+
+    /// Gets the address of a token on a specific chain.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the token is not found or not available on the chain.
+    pub fn get_address(&self, symbol: &str, chain: ChainId) -> TokenResult<&str> {
+        let token = self
+            .tokens
+            .get(symbol)
+            .ok_or_else(|| TokenError::TokenNotFound(symbol.to_string()))?;
+
+        token
+            .address(chain)
+            .ok_or_else(|| TokenError::NotOnChain(symbol.to_string(), chain))
+    }
+
+    /// Gets token info by address on a specific chain.
+    #[must_use]
+    pub fn get_by_address(&self, address: &str, chain: ChainId) -> Option<&TokenInfo> {
+        let normalized = address.to_lowercase();
+        self.tokens.values().find(|t| {
+            t.address(chain)
+                .map(|a| a.to_lowercase() == normalized)
+                .unwrap_or(false)
+        })
+    }
+
+    /// Returns all registered token symbols.
+    #[must_use]
+    pub fn symbols(&self) -> Vec<&str> {
+        self.tokens.keys().map(String::as_str).collect()
+    }
+
+    /// Returns the number of registered tokens.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.tokens.len()
+    }
+
+    /// Returns true if no tokens are registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+
+    /// Returns all tokens available on a specific chain.
+    #[must_use]
+    pub fn tokens_on_chain(&self, chain: ChainId) -> Vec<&TokenInfo> {
+        self.tokens
+            .values()
+            .filter(|t| t.is_available_on(chain))
+            .collect()
+    }
+}
+
+/// Validates an Ethereum address format.
+///
+/// # Arguments
+///
+/// * `address` - The address to validate
+///
+/// # Returns
+///
+/// True if the address is a valid Ethereum address format.
+#[must_use]
+pub fn is_valid_address(address: &str) -> bool {
+    if !address.starts_with("0x") {
+        return false;
+    }
+
+    let hex_part = &address[2..];
+    hex_part.len() == 40 && hex_part.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Normalizes an Ethereum address to lowercase with 0x prefix.
+///
+/// # Arguments
+///
+/// * `address` - The address to normalize
+///
+/// # Errors
+///
+/// Returns an error if the address format is invalid.
+pub fn normalize_address(address: &str) -> TokenResult<String> {
+    if !is_valid_address(address) {
+        return Err(TokenError::InvalidAddress(address.to_string()));
+    }
+
+    Ok(address.to_lowercase())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_info_new() {
+        let token = TokenInfo::new("WETH", "Wrapped Ether", 18);
+        assert_eq!(token.symbol, "WETH");
+        assert_eq!(token.name, "Wrapped Ether");
+        assert_eq!(token.decimals, 18);
+        assert!(token.addresses.is_empty());
+    }
+
+    #[test]
+    fn token_info_with_address() {
+        let token = TokenInfo::new("WETH", "Wrapped Ether", 18).with_address(
+            ChainId::Ethereum,
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        );
+
+        assert_eq!(
+            token.address(ChainId::Ethereum),
+            Some("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+        );
+        assert!(token.address(ChainId::Polygon).is_none());
+    }
+
+    #[test]
+    fn token_info_available_chains() {
+        let token = TokenInfo::new("WETH", "Wrapped Ether", 18)
+            .with_address(ChainId::Ethereum, "0x1")
+            .with_address(ChainId::Polygon, "0x2");
+
+        let chains = token.available_chains();
+        assert_eq!(chains.len(), 2);
+        assert!(token.is_available_on(ChainId::Ethereum));
+        assert!(token.is_available_on(ChainId::Polygon));
+        assert!(!token.is_available_on(ChainId::Arbitrum));
+    }
+
+    #[test]
+    fn token_registry_new() {
+        let registry = TokenRegistry::new();
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn token_registry_with_common_tokens() {
+        let registry = TokenRegistry::with_common_tokens();
+        assert!(!registry.is_empty());
+        assert!(registry.get("WETH").is_some());
+        assert!(registry.get("USDC").is_some());
+        assert!(registry.get("USDT").is_some());
+        assert!(registry.get("DAI").is_some());
+        assert!(registry.get("WBTC").is_some());
+    }
+
+    #[test]
+    fn token_registry_get_address() {
+        let registry = TokenRegistry::with_common_tokens();
+
+        let address = registry.get_address("WETH", ChainId::Ethereum).unwrap();
+        assert_eq!(address, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+    }
+
+    #[test]
+    fn token_registry_get_address_not_found() {
+        let registry = TokenRegistry::with_common_tokens();
+
+        let result = registry.get_address("UNKNOWN", ChainId::Ethereum);
+        assert!(matches!(result, Err(TokenError::TokenNotFound(_))));
+    }
+
+    #[test]
+    fn token_registry_get_address_not_on_chain() {
+        let mut registry = TokenRegistry::new();
+        registry.register(TokenInfo::new("TEST", "Test Token", 18).with_address(
+            ChainId::Ethereum,
+            "0x1234567890123456789012345678901234567890",
+        ));
+
+        let result = registry.get_address("TEST", ChainId::Polygon);
+        assert!(matches!(result, Err(TokenError::NotOnChain(_, _))));
+    }
+
+    #[test]
+    fn token_registry_get_by_address() {
+        let registry = TokenRegistry::with_common_tokens();
+
+        let token = registry
+            .get_by_address(
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                ChainId::Ethereum,
+            )
+            .unwrap();
+        assert_eq!(token.symbol, "WETH");
+    }
+
+    #[test]
+    fn token_registry_get_by_address_case_insensitive() {
+        let registry = TokenRegistry::with_common_tokens();
+
+        let token = registry
+            .get_by_address(
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                ChainId::Ethereum,
+            )
+            .unwrap();
+        assert_eq!(token.symbol, "WETH");
+    }
+
+    #[test]
+    fn token_registry_tokens_on_chain() {
+        let registry = TokenRegistry::with_common_tokens();
+
+        let tokens = registry.tokens_on_chain(ChainId::Ethereum);
+        assert!(!tokens.is_empty());
+        assert!(tokens.iter().any(|t| t.symbol == "WETH"));
+    }
+
+    #[test]
+    fn is_valid_address_valid() {
+        assert!(is_valid_address(
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+        ));
+        assert!(is_valid_address(
+            "0x0000000000000000000000000000000000000000"
+        ));
+    }
+
+    #[test]
+    fn is_valid_address_invalid() {
+        assert!(!is_valid_address(
+            "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+        )); // no 0x
+        assert!(!is_valid_address(
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc"
+        )); // too short
+        assert!(!is_valid_address(
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2X"
+        )); // too long
+        assert!(!is_valid_address(
+            "0xGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG"
+        )); // invalid chars
+    }
+
+    #[test]
+    fn normalize_address_valid() {
+        let result = normalize_address("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap();
+        assert_eq!(result, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+    }
+
+    #[test]
+    fn normalize_address_invalid() {
+        let result = normalize_address("invalid");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn token_error_display() {
+        let err = TokenError::TokenNotFound("UNKNOWN".to_string());
+        assert_eq!(err.to_string(), "token not found: UNKNOWN");
+
+        let err = TokenError::NotOnChain("WETH".to_string(), ChainId::Polygon);
+        assert!(err.to_string().contains("WETH"));
+    }
+}


### PR DESCRIPTION
## Summary

Implement multi-chain configuration and token registry for blockchain infrastructure.

## Changes

### ChainConfig
| Field | Type | Description |
|-------|------|-------------|
| `chain_id` | `ChainId` | Chain identifier |
| `rpc_urls` | `Vec<String>` | Primary + backup RPC endpoints |
| `block_time_ms` | `u64` | Average block time |
| `gas_price_strategy` | `GasPriceStrategy` | Legacy or EIP-1559 |
| `confirmations` | `u64` | Required confirmations |
| `gas_buffer_percent` | `u64` | Gas estimation buffer |

### TokenRegistry
- Pre-populated with common tokens: WETH, USDC, USDT, DAI, WBTC
- Lookup by symbol, address, or chain
- Case-insensitive address matching
- Chain availability checks

### Configuration Utilities
- Environment variable substitution (`${VAR_NAME}` syntax)
- TOML parsing for chain configuration
- Address validation and normalization

## Technical Decisions

- **GasPriceStrategy enum**: Separates legacy vs EIP-1559 at config level
- **ChainConfigBuilder**: Fluent builder with automatic defaults based on chain capabilities
- **TokenInfo per-chain addresses**: HashMap<ChainId, String> for O(1) lookup
- **Case-insensitive address matching**: Normalizes to lowercase for comparison

## Testing

- [x] Unit tests added (30 new tests, 666 total)
- [x] ChainConfig creation and validation
- [x] TokenRegistry lookup by symbol and chain
- [x] Environment variable substitution
- [x] Address validation

## Checklist

- [x] Code follows `.internalDoc/09-rust-guidelines.md`
- [x] Documentation updated (doc comments on all public items)
- [x] No warnings from `cargo clippy`

Closes #34