### PR TITLE
M3 #35: Implement CreateRFQ use case

### DIFF
--- a/src/application/dto/mod.rs
+++ b/src/application/dto/mod.rs
@@ -1,5 +1,10 @@
 //! # Data Transfer Objects
 //!
 //! DTOs for use case input/output, decoupling API from domain.
+//!
+//! These objects provide a clean interface between the API layer and
+//! the application layer, handling validation and serialization.
 
 pub mod rfq_dto;
+
+pub use rfq_dto::{CreateRfqRequest, CreateRfqResponse};

--- a/src/application/dto/rfq_dto.rs
+++ b/src/application/dto/rfq_dto.rs
@@ -1,5 +1,246 @@
 //! # RFQ DTOs
 //!
 //! Data transfer objects for RFQ operations.
+//!
+//! These DTOs decouple the API layer from the domain layer, providing
+//! validation and serialization for RFQ-related requests and responses.
 
-// TODO: Implement in M3 #35
+use crate::domain::value_objects::enums::{AssetClass, SettlementMethod};
+use crate::domain::value_objects::symbol::Symbol;
+use crate::domain::value_objects::timestamp::Timestamp;
+use crate::domain::value_objects::{Instrument, OrderSide, Quantity, RfqId, RfqState};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Request to create a new RFQ.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateRfqRequest {
+    /// The client ID requesting the quote.
+    pub client_id: String,
+    /// Base asset symbol (e.g., "BTC").
+    pub base_asset: String,
+    /// Quote asset symbol (e.g., "USD").
+    pub quote_asset: String,
+    /// Buy or sell side.
+    pub side: OrderSide,
+    /// Requested quantity.
+    pub quantity: f64,
+    /// Expiry duration in seconds from now.
+    pub expiry_seconds: u64,
+}
+
+impl CreateRfqRequest {
+    /// Creates a new CreateRfqRequest.
+    #[must_use]
+    pub fn new(
+        client_id: impl Into<String>,
+        base_asset: impl Into<String>,
+        quote_asset: impl Into<String>,
+        side: OrderSide,
+        quantity: f64,
+        expiry_seconds: u64,
+    ) -> Self {
+        Self {
+            client_id: client_id.into(),
+            base_asset: base_asset.into(),
+            quote_asset: quote_asset.into(),
+            side,
+            quantity,
+            expiry_seconds,
+        }
+    }
+
+    /// Validates the request fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error message if validation fails.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.client_id.is_empty() {
+            return Err("client_id cannot be empty".to_string());
+        }
+
+        if self.base_asset.is_empty() {
+            return Err("base_asset cannot be empty".to_string());
+        }
+
+        if self.quote_asset.is_empty() {
+            return Err("quote_asset cannot be empty".to_string());
+        }
+
+        if self.quantity <= 0.0 {
+            return Err("quantity must be positive".to_string());
+        }
+
+        if self.expiry_seconds == 0 {
+            return Err("expiry_seconds must be greater than 0".to_string());
+        }
+
+        Ok(())
+    }
+
+    /// Converts the request to domain types.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if conversion fails.
+    pub fn to_domain_types(&self) -> Result<(Instrument, Quantity, Timestamp), String> {
+        let symbol_str = format!("{}/{}", self.base_asset, self.quote_asset);
+        let symbol = Symbol::new(&symbol_str).map_err(|e| e.to_string())?;
+
+        let instrument =
+            Instrument::new(symbol, AssetClass::CryptoSpot, SettlementMethod::default());
+
+        let quantity = Quantity::new(self.quantity).map_err(|e| e.to_string())?;
+
+        let expires_at = Timestamp::now().add_secs(self.expiry_seconds as i64);
+
+        Ok((instrument, quantity, expires_at))
+    }
+}
+
+impl fmt::Display for CreateRfqRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CreateRfqRequest {{ client: {}, {}/{} {} {} }}",
+            self.client_id, self.base_asset, self.quote_asset, self.side, self.quantity
+        )
+    }
+}
+
+/// Response after creating an RFQ.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateRfqResponse {
+    /// The created RFQ ID.
+    pub rfq_id: RfqId,
+    /// Current state of the RFQ.
+    pub state: RfqState,
+    /// When the RFQ was created.
+    pub created_at: Timestamp,
+    /// When the RFQ expires.
+    pub expires_at: Timestamp,
+}
+
+impl CreateRfqResponse {
+    /// Creates a new CreateRfqResponse.
+    #[must_use]
+    pub fn new(
+        rfq_id: RfqId,
+        state: RfqState,
+        created_at: Timestamp,
+        expires_at: Timestamp,
+    ) -> Self {
+        Self {
+            rfq_id,
+            state,
+            created_at,
+            expires_at,
+        }
+    }
+}
+
+impl fmt::Display for CreateRfqResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CreateRfqResponse {{ rfq_id: {}, state: {} }}",
+            self.rfq_id, self.state
+        )
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_rfq_request_new() {
+        let request = CreateRfqRequest::new("client-1", "BTC", "USD", OrderSide::Buy, 1.5, 300);
+
+        assert_eq!(request.client_id, "client-1");
+        assert_eq!(request.base_asset, "BTC");
+        assert_eq!(request.quote_asset, "USD");
+        assert_eq!(request.side, OrderSide::Buy);
+        assert!((request.quantity - 1.5).abs() < f64::EPSILON);
+        assert_eq!(request.expiry_seconds, 300);
+    }
+
+    #[test]
+    fn create_rfq_request_validate_success() {
+        let request = CreateRfqRequest::new("client-1", "BTC", "USD", OrderSide::Buy, 1.5, 300);
+        assert!(request.validate().is_ok());
+    }
+
+    #[test]
+    fn create_rfq_request_validate_empty_client_id() {
+        let request = CreateRfqRequest::new("", "BTC", "USD", OrderSide::Buy, 1.5, 300);
+        assert!(request.validate().is_err());
+    }
+
+    #[test]
+    fn create_rfq_request_validate_empty_base_asset() {
+        let request = CreateRfqRequest::new("client-1", "", "USD", OrderSide::Buy, 1.5, 300);
+        assert!(request.validate().is_err());
+    }
+
+    #[test]
+    fn create_rfq_request_validate_zero_quantity() {
+        let request = CreateRfqRequest::new("client-1", "BTC", "USD", OrderSide::Buy, 0.0, 300);
+        assert!(request.validate().is_err());
+    }
+
+    #[test]
+    fn create_rfq_request_validate_negative_quantity() {
+        let request = CreateRfqRequest::new("client-1", "BTC", "USD", OrderSide::Buy, -1.0, 300);
+        assert!(request.validate().is_err());
+    }
+
+    #[test]
+    fn create_rfq_request_validate_zero_expiry() {
+        let request = CreateRfqRequest::new("client-1", "BTC", "USD", OrderSide::Buy, 1.5, 0);
+        assert!(request.validate().is_err());
+    }
+
+    #[test]
+    fn create_rfq_request_to_domain_types() {
+        let request = CreateRfqRequest::new("client-1", "BTC", "USD", OrderSide::Buy, 1.5, 300);
+        let result = request.to_domain_types();
+        assert!(result.is_ok());
+
+        let (instrument, _quantity, expires_at) = result.unwrap();
+        assert_eq!(instrument.symbol().base_asset(), "BTC");
+        assert_eq!(instrument.symbol().quote_asset(), "USD");
+        assert!(!expires_at.is_expired());
+    }
+
+    #[test]
+    fn create_rfq_request_display() {
+        let request = CreateRfqRequest::new("client-1", "BTC", "USD", OrderSide::Buy, 1.5, 300);
+        let display = request.to_string();
+        assert!(display.contains("client-1"));
+        assert!(display.contains("BTC/USD"));
+    }
+
+    #[test]
+    fn create_rfq_response_new() {
+        let rfq_id = RfqId::new_v4();
+        let now = Timestamp::now();
+        let expires = now.add_secs(300);
+        let response = CreateRfqResponse::new(rfq_id, RfqState::Created, now, expires);
+
+        assert_eq!(response.rfq_id, rfq_id);
+        assert_eq!(response.state, RfqState::Created);
+    }
+
+    #[test]
+    fn create_rfq_response_display() {
+        let rfq_id = RfqId::new_v4();
+        let now = Timestamp::now();
+        let expires = now.add_secs(300);
+        let response = CreateRfqResponse::new(rfq_id, RfqState::Created, now, expires);
+        let display = response.to_string();
+        assert!(display.contains("rfq_id"));
+    }
+}

--- a/src/application/error.rs
+++ b/src/application/error.rs
@@ -1,5 +1,151 @@
 //! # Application Errors
 //!
 //! Error types for the application layer.
+//!
+//! These errors represent failures that can occur during use case execution,
+//! including validation failures, business rule violations, and infrastructure errors.
 
-// TODO: Implement in M3 #43
+use crate::domain::errors::DomainError;
+use std::fmt;
+use thiserror::Error;
+
+/// Application layer error.
+#[derive(Debug, Error)]
+pub enum ApplicationError {
+    /// Client not found.
+    #[error("client not found: {0}")]
+    ClientNotFound(String),
+
+    /// Client is not active.
+    #[error("client not active: {0}")]
+    ClientNotActive(String),
+
+    /// Instrument not supported.
+    #[error("instrument not supported: {0}")]
+    InstrumentNotSupported(String),
+
+    /// Compliance check failed.
+    #[error("compliance check failed: {0}")]
+    ComplianceFailed(String),
+
+    /// Request validation failed.
+    #[error("validation error: {0}")]
+    ValidationError(String),
+
+    /// Domain error.
+    #[error("domain error: {0}")]
+    DomainError(#[from] DomainError),
+
+    /// Repository error.
+    #[error("repository error: {0}")]
+    RepositoryError(String),
+
+    /// Event publishing error.
+    #[error("event publishing error: {0}")]
+    EventPublishError(String),
+
+    /// Internal error.
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl ApplicationError {
+    /// Creates a client not found error.
+    #[must_use]
+    pub fn client_not_found(client_id: impl Into<String>) -> Self {
+        Self::ClientNotFound(client_id.into())
+    }
+
+    /// Creates a client not active error.
+    #[must_use]
+    pub fn client_not_active(client_id: impl Into<String>) -> Self {
+        Self::ClientNotActive(client_id.into())
+    }
+
+    /// Creates an instrument not supported error.
+    #[must_use]
+    pub fn instrument_not_supported(instrument: impl fmt::Display) -> Self {
+        Self::InstrumentNotSupported(instrument.to_string())
+    }
+
+    /// Creates a compliance failed error.
+    #[must_use]
+    pub fn compliance_failed(reason: impl Into<String>) -> Self {
+        Self::ComplianceFailed(reason.into())
+    }
+
+    /// Creates a validation error.
+    #[must_use]
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self::ValidationError(message.into())
+    }
+
+    /// Creates a repository error.
+    #[must_use]
+    pub fn repository(message: impl Into<String>) -> Self {
+        Self::RepositoryError(message.into())
+    }
+
+    /// Creates an event publish error.
+    #[must_use]
+    pub fn event_publish(message: impl Into<String>) -> Self {
+        Self::EventPublishError(message.into())
+    }
+
+    /// Creates an internal error.
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+/// Result type for application operations.
+pub type ApplicationResult<T> = Result<T, ApplicationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn application_error_client_not_found() {
+        let err = ApplicationError::client_not_found("client-123");
+        assert!(err.to_string().contains("client-123"));
+    }
+
+    #[test]
+    fn application_error_client_not_active() {
+        let err = ApplicationError::client_not_active("client-456");
+        assert!(err.to_string().contains("client-456"));
+    }
+
+    #[test]
+    fn application_error_instrument_not_supported() {
+        let err = ApplicationError::instrument_not_supported("BTC/XYZ");
+        assert!(err.to_string().contains("BTC/XYZ"));
+    }
+
+    #[test]
+    fn application_error_compliance_failed() {
+        let err = ApplicationError::compliance_failed("KYC not verified");
+        assert!(err.to_string().contains("KYC not verified"));
+    }
+
+    #[test]
+    fn application_error_validation() {
+        let err = ApplicationError::validation("quantity must be positive");
+        assert!(err.to_string().contains("quantity must be positive"));
+    }
+
+    #[test]
+    fn application_error_repository() {
+        let err = ApplicationError::repository("database connection failed");
+        assert!(err.to_string().contains("database connection failed"));
+    }
+
+    #[test]
+    fn application_error_from_domain_error() {
+        let domain_err = DomainError::InvalidQuantity("negative".to_string());
+        let app_err: ApplicationError = domain_err.into();
+        assert!(app_err.to_string().contains("negative"));
+    }
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! ## Use Cases
 //!
-//! - `CreateRfqUseCase`: Create a new RFQ request
+//! - [`CreateRfqUseCase`]: Create a new RFQ request
 //! - `CollectQuotesUseCase`: Gather quotes from venues
 //! - `ExecuteTradeUseCase`: Execute a trade against a quote
 //!
@@ -20,3 +20,10 @@ pub mod dto;
 pub mod error;
 pub mod services;
 pub mod use_cases;
+
+pub use dto::{CreateRfqRequest, CreateRfqResponse};
+pub use error::{ApplicationError, ApplicationResult};
+pub use use_cases::{
+    ClientRepository, ComplianceService, CreateRfqUseCase, EventPublisher, InstrumentRegistry,
+    RfqRepository,
+};

--- a/src/application/use_cases/create_rfq.rs
+++ b/src/application/use_cases/create_rfq.rs
@@ -1,5 +1,461 @@
 //! # Create RFQ Use Case
 //!
 //! Use case for creating new RFQ requests.
+//!
+//! This use case orchestrates the creation of a new RFQ, including:
+//! - Request validation
+//! - Client verification
+//! - Instrument validation
+//! - Compliance pre-checks
+//! - RFQ persistence
+//! - Domain event publishing
 
-// TODO: Implement in M3 #35
+use crate::application::dto::rfq_dto::{CreateRfqRequest, CreateRfqResponse};
+use crate::application::error::{ApplicationError, ApplicationResult};
+use crate::domain::entities::rfq::{ComplianceResult, Rfq};
+use crate::domain::events::rfq_events::RfqCreated;
+use crate::domain::value_objects::{CounterpartyId, RfqId};
+use async_trait::async_trait;
+use std::fmt;
+use std::sync::Arc;
+
+/// Repository for RFQ persistence.
+#[async_trait]
+pub trait RfqRepository: Send + Sync + fmt::Debug {
+    /// Saves an RFQ to the repository.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if persistence fails.
+    async fn save(&self, rfq: &Rfq) -> Result<(), String>;
+
+    /// Finds an RFQ by ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    async fn find_by_id(&self, id: RfqId) -> Result<Option<Rfq>, String>;
+}
+
+/// Publisher for domain events.
+#[async_trait]
+pub trait EventPublisher: Send + Sync + fmt::Debug {
+    /// Publishes an RFQ created event.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if publishing fails.
+    async fn publish_rfq_created(&self, event: RfqCreated) -> Result<(), String>;
+}
+
+/// Service for compliance checks.
+#[async_trait]
+pub trait ComplianceService: Send + Sync + fmt::Debug {
+    /// Performs a pre-check for RFQ creation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the check fails.
+    async fn pre_check(
+        &self,
+        client_id: &CounterpartyId,
+        base_asset: &str,
+        quote_asset: &str,
+        quantity: f64,
+    ) -> Result<ComplianceResult, String>;
+}
+
+/// Repository for client information.
+#[async_trait]
+pub trait ClientRepository: Send + Sync + fmt::Debug {
+    /// Checks if a client exists.
+    async fn exists(&self, client_id: &str) -> Result<bool, String>;
+
+    /// Checks if a client is active.
+    async fn is_active(&self, client_id: &str) -> Result<bool, String>;
+}
+
+/// Registry for supported instruments.
+#[async_trait]
+pub trait InstrumentRegistry: Send + Sync + fmt::Debug {
+    /// Checks if an instrument is supported.
+    async fn is_supported(&self, base_asset: &str, quote_asset: &str) -> Result<bool, String>;
+}
+
+/// Use case for creating a new RFQ.
+#[derive(Debug)]
+pub struct CreateRfqUseCase {
+    rfq_repository: Arc<dyn RfqRepository>,
+    event_publisher: Arc<dyn EventPublisher>,
+    compliance_service: Arc<dyn ComplianceService>,
+    client_repository: Arc<dyn ClientRepository>,
+    instrument_registry: Arc<dyn InstrumentRegistry>,
+}
+
+impl CreateRfqUseCase {
+    /// Creates a new CreateRfqUseCase with all dependencies.
+    #[must_use]
+    pub fn new(
+        rfq_repository: Arc<dyn RfqRepository>,
+        event_publisher: Arc<dyn EventPublisher>,
+        compliance_service: Arc<dyn ComplianceService>,
+        client_repository: Arc<dyn ClientRepository>,
+        instrument_registry: Arc<dyn InstrumentRegistry>,
+    ) -> Self {
+        Self {
+            rfq_repository,
+            event_publisher,
+            compliance_service,
+            client_repository,
+            instrument_registry,
+        }
+    }
+
+    /// Executes the create RFQ use case.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The create RFQ request
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Request validation fails
+    /// - Client does not exist or is not active
+    /// - Instrument is not supported
+    /// - Compliance check fails
+    /// - Persistence fails
+    /// - Event publishing fails
+    pub async fn execute(&self, request: CreateRfqRequest) -> ApplicationResult<CreateRfqResponse> {
+        // 1. Validate request
+        request.validate().map_err(ApplicationError::validation)?;
+
+        // 2. Check client exists
+        let client_exists = self
+            .client_repository
+            .exists(&request.client_id)
+            .await
+            .map_err(ApplicationError::repository)?;
+
+        if !client_exists {
+            return Err(ApplicationError::client_not_found(&request.client_id));
+        }
+
+        // 3. Check client is active
+        let client_active = self
+            .client_repository
+            .is_active(&request.client_id)
+            .await
+            .map_err(ApplicationError::repository)?;
+
+        if !client_active {
+            return Err(ApplicationError::client_not_active(&request.client_id));
+        }
+
+        // 4. Check instrument is supported
+        let instrument_supported = self
+            .instrument_registry
+            .is_supported(&request.base_asset, &request.quote_asset)
+            .await
+            .map_err(ApplicationError::repository)?;
+
+        if !instrument_supported {
+            return Err(ApplicationError::instrument_not_supported(format!(
+                "{}/{}",
+                request.base_asset, request.quote_asset
+            )));
+        }
+
+        // 5. Convert to domain types
+        let (instrument, quantity, expires_at) = request
+            .to_domain_types()
+            .map_err(ApplicationError::validation)?;
+
+        let client_id = CounterpartyId::new(&request.client_id);
+
+        // 6. Run compliance pre-check
+        let compliance_result = self
+            .compliance_service
+            .pre_check(
+                &client_id,
+                &request.base_asset,
+                &request.quote_asset,
+                request.quantity,
+            )
+            .await
+            .map_err(ApplicationError::repository)?;
+
+        if !compliance_result.passed {
+            return Err(ApplicationError::compliance_failed(
+                compliance_result
+                    .reason
+                    .unwrap_or_else(|| "unknown reason".to_string()),
+            ));
+        }
+
+        // 7. Create RFQ aggregate
+        let rfq = Rfq::new(client_id, instrument, request.side, quantity, expires_at)?;
+
+        // 8. Persist RFQ
+        self.rfq_repository
+            .save(&rfq)
+            .await
+            .map_err(ApplicationError::repository)?;
+
+        // 9. Publish domain event
+        let event = RfqCreated::new(
+            rfq.id(),
+            rfq.client_id().clone(),
+            rfq.instrument().clone(),
+            rfq.side(),
+            rfq.quantity(),
+            rfq.expires_at(),
+        );
+
+        self.event_publisher
+            .publish_rfq_created(event)
+            .await
+            .map_err(ApplicationError::event_publish)?;
+
+        // 10. Return response
+        Ok(CreateRfqResponse::new(
+            rfq.id(),
+            rfq.state(),
+            rfq.created_at(),
+            rfq.expires_at(),
+        ))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::domain::value_objects::OrderSide;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    struct MockRfqRepository {
+        rfqs: Mutex<HashMap<RfqId, Rfq>>,
+    }
+
+    #[async_trait]
+    impl RfqRepository for MockRfqRepository {
+        async fn save(&self, rfq: &Rfq) -> Result<(), String> {
+            self.rfqs.lock().unwrap().insert(rfq.id(), rfq.clone());
+            Ok(())
+        }
+
+        async fn find_by_id(&self, id: RfqId) -> Result<Option<Rfq>, String> {
+            Ok(self.rfqs.lock().unwrap().get(&id).cloned())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct MockEventPublisher {
+        events: Mutex<Vec<RfqCreated>>,
+    }
+
+    #[async_trait]
+    impl EventPublisher for MockEventPublisher {
+        async fn publish_rfq_created(&self, event: RfqCreated) -> Result<(), String> {
+            self.events.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockComplianceService {
+        should_pass: bool,
+    }
+
+    impl MockComplianceService {
+        fn passing() -> Self {
+            Self { should_pass: true }
+        }
+
+        fn failing() -> Self {
+            Self { should_pass: false }
+        }
+    }
+
+    #[async_trait]
+    impl ComplianceService for MockComplianceService {
+        async fn pre_check(
+            &self,
+            _client_id: &CounterpartyId,
+            _base_asset: &str,
+            _quote_asset: &str,
+            _quantity: f64,
+        ) -> Result<ComplianceResult, String> {
+            if self.should_pass {
+                Ok(ComplianceResult::passed())
+            } else {
+                Ok(ComplianceResult::failed("compliance check failed"))
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockClientRepository {
+        existing_clients: Vec<String>,
+        active_clients: Vec<String>,
+    }
+
+    impl MockClientRepository {
+        fn with_client(client_id: &str) -> Self {
+            Self {
+                existing_clients: vec![client_id.to_string()],
+                active_clients: vec![client_id.to_string()],
+            }
+        }
+
+        fn empty() -> Self {
+            Self {
+                existing_clients: vec![],
+                active_clients: vec![],
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ClientRepository for MockClientRepository {
+        async fn exists(&self, client_id: &str) -> Result<bool, String> {
+            Ok(self.existing_clients.contains(&client_id.to_string()))
+        }
+
+        async fn is_active(&self, client_id: &str) -> Result<bool, String> {
+            Ok(self.active_clients.contains(&client_id.to_string()))
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockInstrumentRegistry {
+        supported: Vec<(String, String)>,
+    }
+
+    impl MockInstrumentRegistry {
+        fn with_instrument(base: &str, quote: &str) -> Self {
+            Self {
+                supported: vec![(base.to_string(), quote.to_string())],
+            }
+        }
+    }
+
+    #[async_trait]
+    impl InstrumentRegistry for MockInstrumentRegistry {
+        async fn is_supported(&self, base_asset: &str, quote_asset: &str) -> Result<bool, String> {
+            Ok(self
+                .supported
+                .iter()
+                .any(|(b, q)| b == base_asset && q == quote_asset))
+        }
+    }
+
+    fn create_use_case(
+        client_repo: impl ClientRepository + 'static,
+        instrument_registry: impl InstrumentRegistry + 'static,
+        compliance_service: impl ComplianceService + 'static,
+    ) -> CreateRfqUseCase {
+        CreateRfqUseCase::new(
+            Arc::new(MockRfqRepository::default()),
+            Arc::new(MockEventPublisher::default()),
+            Arc::new(compliance_service),
+            Arc::new(client_repo),
+            Arc::new(instrument_registry),
+        )
+    }
+
+    #[tokio::test]
+    async fn execute_success() {
+        let use_case = create_use_case(
+            MockClientRepository::with_client("client-1"),
+            MockInstrumentRegistry::with_instrument("BTC", "USD"),
+            MockComplianceService::passing(),
+        );
+
+        let request = CreateRfqRequest::new("client-1", "BTC", "USD", OrderSide::Buy, 1.5, 300);
+        let result = use_case.execute(request).await;
+
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(
+            response.state,
+            crate::domain::value_objects::RfqState::Created
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_client_not_found() {
+        let use_case = create_use_case(
+            MockClientRepository::empty(),
+            MockInstrumentRegistry::with_instrument("BTC", "USD"),
+            MockComplianceService::passing(),
+        );
+
+        let request =
+            CreateRfqRequest::new("unknown-client", "BTC", "USD", OrderSide::Buy, 1.5, 300);
+        let result = use_case.execute(request).await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ApplicationError::ClientNotFound(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn execute_instrument_not_supported() {
+        let use_case = create_use_case(
+            MockClientRepository::with_client("client-1"),
+            MockInstrumentRegistry::with_instrument("ETH", "USD"),
+            MockComplianceService::passing(),
+        );
+
+        let request = CreateRfqRequest::new("client-1", "BTC", "USD", OrderSide::Buy, 1.5, 300);
+        let result = use_case.execute(request).await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ApplicationError::InstrumentNotSupported(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn execute_compliance_failed() {
+        let use_case = create_use_case(
+            MockClientRepository::with_client("client-1"),
+            MockInstrumentRegistry::with_instrument("BTC", "USD"),
+            MockComplianceService::failing(),
+        );
+
+        let request = CreateRfqRequest::new("client-1", "BTC", "USD", OrderSide::Buy, 1.5, 300);
+        let result = use_case.execute(request).await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ApplicationError::ComplianceFailed(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn execute_validation_error() {
+        let use_case = create_use_case(
+            MockClientRepository::with_client("client-1"),
+            MockInstrumentRegistry::with_instrument("BTC", "USD"),
+            MockComplianceService::passing(),
+        );
+
+        let request = CreateRfqRequest::new("", "BTC", "USD", OrderSide::Buy, 1.5, 300);
+        let result = use_case.execute(request).await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ApplicationError::ValidationError(_)
+        ));
+    }
+}

--- a/src/application/use_cases/mod.rs
+++ b/src/application/use_cases/mod.rs
@@ -1,7 +1,15 @@
 //! # Use Cases
 //!
 //! Application use cases implementing business workflows.
+//!
+//! Each use case orchestrates domain objects to perform a specific
+//! business operation, handling validation, persistence, and events.
 
 pub mod collect_quotes;
 pub mod create_rfq;
 pub mod execute_trade;
+
+pub use create_rfq::{
+    ClientRepository, ComplianceService, CreateRfqUseCase, EventPublisher, InstrumentRegistry,
+    RfqRepository,
+};


### PR DESCRIPTION
## Summary

Implement the CreateRFQ use case for initiating new RFQ requests with full validation, compliance checks, and event publishing.

## Changes

### DTOs (`src/application/dto/rfq_dto.rs`)
| Type | Fields | Description |
|------|--------|-------------|
| `CreateRfqRequest` | client_id, base_asset, quote_asset, side, quantity, expiry_seconds | Input DTO with validation |
| `CreateRfqResponse` | rfq_id, state, created_at, expires_at | Output DTO |

### ApplicationError (`src/application/error.rs`)
| Variant | Description |
|---------|-------------|
| `ClientNotFound` | Client does not exist |
| `ClientNotActive` | Client is not active |
| `InstrumentNotSupported` | Instrument not tradeable |
| `ComplianceFailed` | Compliance pre-check failed |
| `ValidationError` | Request validation failed |
| `DomainError` | Wraps domain layer errors |
| `RepositoryError` | Persistence failure |
| `EventPublishError` | Event publishing failure |

### CreateRfqUseCase (`src/application/use_cases/create_rfq.rs`)
Dependencies (trait objects for DI):
- `RfqRepository`: RFQ persistence
- `EventPublisher`: Domain event publishing
- `ComplianceService`: KYC/AML pre-checks
- `ClientRepository`: Client validation
- `InstrumentRegistry`: Instrument validation

Workflow:
1. Validate request fields
2. Check client exists and is active
3. Check instrument is supported
4. Run compliance pre-check
5. Create RFQ aggregate
6. Persist RFQ
7. Publish RfqCreated event
8. Return response

## Technical Decisions

- **Dependency Injection**: All dependencies are trait objects (`Arc<dyn Trait>`) for testability
- **Error Handling**: Typed `ApplicationError` with factory methods
- **Validation**: Two-stage validation (DTO validation + domain validation)
- **Mock Implementations**: Full mock suite for unit testing

## Testing

- [x] Unit tests added (23 new tests, 689 total)
- [x] CreateRfqRequest validation tests
- [x] CreateRfqUseCase success and failure paths
- [x] Mock implementations for all dependencies

## Checklist

- [x] Code follows `.internalDoc/09-rust-guidelines.md`
- [x] Documentation updated (doc comments on all public items)
- [x] No warnings from `cargo clippy`

Closes #35