### PR TITLE
M3 #38: Implement RankingStrategy trait and implementations

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -24,7 +24,8 @@ pub mod use_cases;
 pub use dto::{CreateRfqRequest, CreateRfqResponse};
 pub use error::{ApplicationError, ApplicationResult};
 pub use services::{
-    AggregationConfig, AggregationError, AggregationResult, BestPriceStrategy,
+    AggregationConfig, AggregationError, AggregationResult, BestPriceStrategy, CompositeStrategy,
+    CompositeStrategyBuilder, CostConfig, LowestCostStrategy, LowestSlippageStrategy,
     QuoteAggregationEngine, RankedQuote, RankingStrategy, WeightedScoreStrategy,
 };
 pub use use_cases::{

--- a/src/application/services/mod.rs
+++ b/src/application/services/mod.rs
@@ -16,5 +16,6 @@ pub use quote_aggregation::{
     AggregationConfig, AggregationError, AggregationResult, QuoteAggregationEngine,
 };
 pub use ranking_strategy::{
-    BestPriceStrategy, RankedQuote, RankingStrategy, WeightedScoreStrategy,
+    BestPriceStrategy, CompositeStrategy, CompositeStrategyBuilder, CostConfig, LowestCostStrategy,
+    LowestSlippageStrategy, RankedQuote, RankingStrategy, WeightedScoreStrategy,
 };

--- a/src/application/services/ranking_strategy.rs
+++ b/src/application/services/ranking_strategy.rs
@@ -223,6 +223,318 @@ impl RankingStrategy for WeightedScoreStrategy {
     }
 }
 
+/// Lowest slippage ranking strategy.
+///
+/// Ranks quotes by estimated slippage, calculated as the deviation
+/// from the best available price. Lower slippage = better score.
+#[derive(Debug, Clone, Default)]
+pub struct LowestSlippageStrategy;
+
+impl LowestSlippageStrategy {
+    /// Creates a new lowest slippage strategy.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Calculates slippage as percentage deviation from best price.
+    fn calculate_slippage(price: f64, best_price: f64) -> f64 {
+        if best_price == 0.0 {
+            return 0.0;
+        }
+        ((price - best_price) / best_price).abs()
+    }
+}
+
+impl RankingStrategy for LowestSlippageStrategy {
+    fn rank(&self, quotes: &[Quote], side: OrderSide) -> Vec<RankedQuote> {
+        if quotes.is_empty() {
+            return Vec::new();
+        }
+
+        let prices: Vec<f64> = quotes
+            .iter()
+            .map(|q| q.price().get().to_f64().unwrap_or(0.0))
+            .collect();
+
+        // Find best price (lowest for buy, highest for sell)
+        let best_price = match side {
+            OrderSide::Buy => prices.iter().cloned().fold(f64::INFINITY, f64::min),
+            OrderSide::Sell => prices.iter().cloned().fold(f64::NEG_INFINITY, f64::max),
+        };
+
+        // Score by slippage (lower slippage = higher score)
+        let mut scored: Vec<(usize, f64)> = quotes
+            .iter()
+            .enumerate()
+            .map(|(i, q)| {
+                let price = q.price().get().to_f64().unwrap_or(0.0);
+                let slippage = Self::calculate_slippage(price, best_price);
+                // Invert slippage so lower slippage = higher score
+                let score = 1.0 - slippage.min(1.0);
+                (i, score)
+            })
+            .collect();
+
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        scored
+            .into_iter()
+            .enumerate()
+            .filter_map(|(rank, (idx, score))| {
+                quotes
+                    .get(idx)
+                    .map(|q| RankedQuote::new(q.clone(), rank + 1, score))
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &'static str {
+        "LowestSlippage"
+    }
+}
+
+/// Configuration for cost calculation.
+#[derive(Debug, Clone)]
+pub struct CostConfig {
+    /// Commission rate as a decimal (e.g., 0.001 = 0.1%).
+    pub commission_rate: f64,
+    /// Estimated gas cost in base currency.
+    pub gas_cost: f64,
+}
+
+impl Default for CostConfig {
+    fn default() -> Self {
+        Self {
+            commission_rate: 0.001, // 0.1% default commission
+            gas_cost: 0.0,
+        }
+    }
+}
+
+impl CostConfig {
+    /// Creates a new cost configuration.
+    #[must_use]
+    pub fn new(commission_rate: f64, gas_cost: f64) -> Self {
+        Self {
+            commission_rate,
+            gas_cost,
+        }
+    }
+}
+
+/// Lowest cost ranking strategy.
+///
+/// Ranks quotes by total cost including:
+/// - Base cost (price × quantity)
+/// - Commission
+/// - Gas costs
+///
+/// Lower total cost = better score.
+#[derive(Debug, Clone, Default)]
+pub struct LowestCostStrategy {
+    /// Cost configuration.
+    config: CostConfig,
+}
+
+impl LowestCostStrategy {
+    /// Creates a new lowest cost strategy with default configuration.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new lowest cost strategy with custom configuration.
+    #[must_use]
+    pub fn with_config(config: CostConfig) -> Self {
+        Self { config }
+    }
+
+    /// Calculates total cost for a quote.
+    fn calculate_total_cost(&self, price: f64, quantity: f64) -> f64 {
+        let base_cost = price * quantity;
+        let commission = base_cost * self.config.commission_rate;
+        base_cost + commission + self.config.gas_cost
+    }
+}
+
+impl RankingStrategy for LowestCostStrategy {
+    fn rank(&self, quotes: &[Quote], side: OrderSide) -> Vec<RankedQuote> {
+        if quotes.is_empty() {
+            return Vec::new();
+        }
+
+        // Calculate costs for all quotes
+        let costs: Vec<f64> = quotes
+            .iter()
+            .map(|q| {
+                let price = q.price().get().to_f64().unwrap_or(0.0);
+                let quantity = q.quantity().get().to_f64().unwrap_or(0.0);
+                self.calculate_total_cost(price, quantity)
+            })
+            .collect();
+
+        let min_cost = costs.iter().cloned().fold(f64::INFINITY, f64::min);
+        let max_cost = costs.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let cost_range = (max_cost - min_cost).max(1.0);
+
+        // Score by cost (lower cost = higher score for buy, opposite for sell)
+        let mut scored: Vec<(usize, f64)> = costs
+            .iter()
+            .enumerate()
+            .map(|(i, &cost)| {
+                let score = match side {
+                    OrderSide::Buy => (max_cost - cost) / cost_range,
+                    OrderSide::Sell => (cost - min_cost) / cost_range,
+                };
+                (i, score)
+            })
+            .collect();
+
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        scored
+            .into_iter()
+            .enumerate()
+            .filter_map(|(rank, (idx, score))| {
+                quotes
+                    .get(idx)
+                    .map(|q| RankedQuote::new(q.clone(), rank + 1, score))
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &'static str {
+        "LowestCost"
+    }
+}
+
+/// Composite ranking strategy.
+///
+/// Combines multiple ranking strategies with configurable weights.
+/// Each strategy's scores are normalized and combined using weighted average.
+#[derive(Debug)]
+pub struct CompositeStrategy {
+    /// Strategies with their weights.
+    strategies: Vec<(Box<dyn RankingStrategy>, f64)>,
+}
+
+impl CompositeStrategy {
+    /// Creates a new composite strategy with the given strategies and weights.
+    ///
+    /// # Arguments
+    ///
+    /// * `strategies` - Vector of (strategy, weight) pairs
+    #[must_use]
+    pub fn new(strategies: Vec<(Box<dyn RankingStrategy>, f64)>) -> Self {
+        Self { strategies }
+    }
+
+    /// Creates a builder for constructing a composite strategy.
+    #[must_use]
+    pub fn builder() -> CompositeStrategyBuilder {
+        CompositeStrategyBuilder::new()
+    }
+}
+
+impl RankingStrategy for CompositeStrategy {
+    fn rank(&self, quotes: &[Quote], side: OrderSide) -> Vec<RankedQuote> {
+        if quotes.is_empty() || self.strategies.is_empty() {
+            return Vec::new();
+        }
+
+        // Collect scores from each strategy
+        let mut combined_scores: Vec<f64> = vec![0.0; quotes.len()];
+        let mut total_weight = 0.0;
+
+        for (strategy, weight) in &self.strategies {
+            let ranked = strategy.rank(quotes, side);
+
+            // Map scores back to original quote indices
+            for rq in ranked {
+                // Find the original index by matching quote
+                if let Some(idx) = quotes.iter().position(|q| q.id() == rq.quote.id()) {
+                    if let Some(score) = combined_scores.get_mut(idx) {
+                        *score += rq.score * weight;
+                    }
+                }
+            }
+            total_weight += weight;
+        }
+
+        // Normalize by total weight
+        if total_weight > 0.0 {
+            for score in &mut combined_scores {
+                *score /= total_weight;
+            }
+        }
+
+        // Create scored pairs and sort
+        let mut scored: Vec<(usize, f64)> = combined_scores.into_iter().enumerate().collect();
+
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        scored
+            .into_iter()
+            .enumerate()
+            .filter_map(|(rank, (idx, score))| {
+                quotes
+                    .get(idx)
+                    .map(|q| RankedQuote::new(q.clone(), rank + 1, score))
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &'static str {
+        "Composite"
+    }
+}
+
+/// Builder for constructing composite strategies.
+#[derive(Debug, Default)]
+pub struct CompositeStrategyBuilder {
+    strategies: Vec<(Box<dyn RankingStrategy>, f64)>,
+}
+
+impl CompositeStrategyBuilder {
+    /// Creates a new builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a strategy with the given weight.
+    #[must_use]
+    pub fn with_strategy(mut self, strategy: Box<dyn RankingStrategy>, weight: f64) -> Self {
+        self.strategies.push((strategy, weight));
+        self
+    }
+
+    /// Adds a best price strategy with the given weight.
+    #[must_use]
+    pub fn with_best_price(self, weight: f64) -> Self {
+        self.with_strategy(Box::new(BestPriceStrategy::new()), weight)
+    }
+
+    /// Adds a lowest slippage strategy with the given weight.
+    #[must_use]
+    pub fn with_lowest_slippage(self, weight: f64) -> Self {
+        self.with_strategy(Box::new(LowestSlippageStrategy::new()), weight)
+    }
+
+    /// Adds a lowest cost strategy with the given weight.
+    #[must_use]
+    pub fn with_lowest_cost(self, weight: f64) -> Self {
+        self.with_strategy(Box::new(LowestCostStrategy::new()), weight)
+    }
+
+    /// Builds the composite strategy.
+    #[must_use]
+    pub fn build(self) -> CompositeStrategy {
+        CompositeStrategy::new(self.strategies)
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::indexing_slicing)]
 mod tests {
@@ -341,5 +653,177 @@ mod tests {
 
         let weighted = WeightedScoreStrategy::default();
         assert_eq!(weighted.name(), "WeightedScore");
+
+        let slippage = LowestSlippageStrategy::new();
+        assert_eq!(slippage.name(), "LowestSlippage");
+
+        let cost = LowestCostStrategy::new();
+        assert_eq!(cost.name(), "LowestCost");
+
+        let composite = CompositeStrategy::builder().build();
+        assert_eq!(composite.name(), "Composite");
+    }
+
+    #[test]
+    fn lowest_slippage_strategy_buy_side() {
+        let strategy = LowestSlippageStrategy::new();
+        let quotes = vec![
+            create_quote(100.0, 1.0, "venue-1"),
+            create_quote(95.0, 1.0, "venue-2"), // Best price (lowest)
+            create_quote(105.0, 1.0, "venue-3"),
+        ];
+
+        let ranked = strategy.rank(&quotes, OrderSide::Buy);
+
+        assert_eq!(ranked.len(), 3);
+        // Best price (95) should have lowest slippage = rank 1
+        assert_eq!(ranked[0].rank, 1);
+        assert!((ranked[0].quote.price().get().to_f64().unwrap() - 95.0).abs() < f64::EPSILON);
+        // Score should be 1.0 for best price (no slippage)
+        assert!((ranked[0].score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lowest_slippage_strategy_sell_side() {
+        let strategy = LowestSlippageStrategy::new();
+        let quotes = vec![
+            create_quote(100.0, 1.0, "venue-1"),
+            create_quote(95.0, 1.0, "venue-2"),
+            create_quote(105.0, 1.0, "venue-3"), // Best price (highest)
+        ];
+
+        let ranked = strategy.rank(&quotes, OrderSide::Sell);
+
+        assert_eq!(ranked.len(), 3);
+        // Best price (105) should have lowest slippage = rank 1
+        assert_eq!(ranked[0].rank, 1);
+        assert!((ranked[0].quote.price().get().to_f64().unwrap() - 105.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lowest_slippage_strategy_empty() {
+        let strategy = LowestSlippageStrategy::new();
+        let ranked = strategy.rank(&[], OrderSide::Buy);
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn lowest_cost_strategy_buy_side() {
+        let strategy = LowestCostStrategy::new();
+        let quotes = vec![
+            create_quote(100.0, 10.0, "venue-1"), // Cost: 100*10 + 0.1% = 1001
+            create_quote(95.0, 10.0, "venue-2"),  // Cost: 95*10 + 0.1% = 950.95 (lowest)
+            create_quote(105.0, 10.0, "venue-3"), // Cost: 105*10 + 0.1% = 1051.05
+        ];
+
+        let ranked = strategy.rank(&quotes, OrderSide::Buy);
+
+        assert_eq!(ranked.len(), 3);
+        // Lowest cost should be rank 1
+        assert_eq!(ranked[0].rank, 1);
+        assert!((ranked[0].quote.price().get().to_f64().unwrap() - 95.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lowest_cost_strategy_with_gas() {
+        let config = CostConfig::new(0.001, 10.0); // 0.1% commission + $10 gas
+        let strategy = LowestCostStrategy::with_config(config);
+        let quotes = vec![
+            create_quote(100.0, 1.0, "venue-1"), // Cost: 100 + 0.1 + 10 = 110.1
+            create_quote(95.0, 1.0, "venue-2"),  // Cost: 95 + 0.095 + 10 = 105.095 (lowest)
+        ];
+
+        let ranked = strategy.rank(&quotes, OrderSide::Buy);
+
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].rank, 1);
+        assert!((ranked[0].quote.price().get().to_f64().unwrap() - 95.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lowest_cost_strategy_empty() {
+        let strategy = LowestCostStrategy::new();
+        let ranked = strategy.rank(&[], OrderSide::Buy);
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn cost_config_default() {
+        let config = CostConfig::default();
+        assert!((config.commission_rate - 0.001).abs() < f64::EPSILON);
+        assert!((config.gas_cost - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn cost_config_custom() {
+        let config = CostConfig::new(0.002, 5.0);
+        assert!((config.commission_rate - 0.002).abs() < f64::EPSILON);
+        assert!((config.gas_cost - 5.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn composite_strategy_single() {
+        let strategy = CompositeStrategy::builder().with_best_price(1.0).build();
+
+        let quotes = vec![
+            create_quote(100.0, 1.0, "venue-1"),
+            create_quote(95.0, 1.0, "venue-2"),
+            create_quote(105.0, 1.0, "venue-3"),
+        ];
+
+        let ranked = strategy.rank(&quotes, OrderSide::Buy);
+
+        assert_eq!(ranked.len(), 3);
+        // Should behave like BestPriceStrategy
+        assert_eq!(ranked[0].rank, 1);
+        assert!((ranked[0].quote.price().get().to_f64().unwrap() - 95.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn composite_strategy_multiple() {
+        let strategy = CompositeStrategy::builder()
+            .with_best_price(0.5)
+            .with_lowest_slippage(0.5)
+            .build();
+
+        let quotes = vec![
+            create_quote(100.0, 1.0, "venue-1"),
+            create_quote(95.0, 1.0, "venue-2"),
+            create_quote(105.0, 1.0, "venue-3"),
+        ];
+
+        let ranked = strategy.rank(&quotes, OrderSide::Buy);
+
+        assert_eq!(ranked.len(), 3);
+        // Both strategies favor lowest price for buy side
+        assert_eq!(ranked[0].rank, 1);
+    }
+
+    #[test]
+    fn composite_strategy_empty_quotes() {
+        let strategy = CompositeStrategy::builder().with_best_price(1.0).build();
+
+        let ranked = strategy.rank(&[], OrderSide::Buy);
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn composite_strategy_no_strategies() {
+        let strategy = CompositeStrategy::builder().build();
+
+        let quotes = vec![create_quote(100.0, 1.0, "venue-1")];
+        let ranked = strategy.rank(&quotes, OrderSide::Buy);
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn composite_strategy_builder() {
+        let strategy = CompositeStrategy::builder()
+            .with_best_price(0.4)
+            .with_lowest_slippage(0.3)
+            .with_lowest_cost(0.3)
+            .build();
+
+        assert_eq!(strategy.strategies.len(), 3);
     }
 }


### PR DESCRIPTION
## Summary

Implement additional ranking strategies for ordering quotes by different criteria, complementing the existing BestPriceStrategy and WeightedScoreStrategy.

## Changes

### New Strategies

| Strategy | Description |
|----------|-------------|
| `LowestSlippageStrategy` | Ranks by deviation from best available price |
| `LowestCostStrategy` | Ranks by total cost (price × qty + commission + gas) |
| `CompositeStrategy` | Weighted combination of multiple strategies |

### LowestSlippageStrategy
- Calculates slippage as percentage deviation from best price
- Best price (lowest for buy, highest for sell) gets score of 1.0
- Lower slippage = higher score

### LowestCostStrategy
- Total cost = base_cost + commission + gas_cost
- `CostConfig`: commission_rate (default 0.1%), gas_cost (default 0)
- Lower total cost = higher score for buy side

### CompositeStrategy
- Combines multiple strategies with configurable weights
- Builder pattern for easy construction:
  ```rust
  CompositeStrategy::builder()
      .with_best_price(0.4)
      .with_lowest_slippage(0.3)
      .with_lowest_cost(0.3)
      .build()
  ```

## Technical Decisions

- **Slippage Calculation**: Uses percentage deviation from best price, capped at 100%
- **Cost Normalization**: Normalizes costs to 0-1 range for fair comparison
- **Composite Scoring**: Weighted average of normalized scores from each strategy
- **Builder Pattern**: Provides fluent API for CompositeStrategy construction

## Testing

- [x] Unit tests added (13 new tests, 733 total)
- [x] LowestSlippageStrategy buy/sell side
- [x] LowestCostStrategy with default and custom config
- [x] CompositeStrategy single/multiple strategies
- [x] Edge cases (empty quotes, no strategies)

## Checklist

- [x] Code follows `.internalDoc/09-rust-guidelines.md`
- [x] Documentation updated (doc comments on all public items)
- [x] No warnings from `cargo clippy`

Closes #38