### PR TITLE
M3 #43: Implement application-level error types

### DIFF
--- a/src/application/error.rs
+++ b/src/application/error.rs
@@ -4,14 +4,187 @@
 //!
 //! These errors represent failures that can occur during use case execution,
 //! including validation failures, business rule violations, and infrastructure errors.
+//!
+//! # Error Hierarchy
+//!
+//! ```text
+//! ApplicationError
+//! ├── Domain(DomainError)         - Business rule violations
+//! ├── Infrastructure(InfrastructureError) - External system failures
+//! ├── Venue(VenueError)           - Venue-specific errors
+//! ├── Validation(String)          - Input validation failures
+//! ├── NotFound(String)            - Resource not found
+//! ├── Unauthorized                - Authentication/authorization failures
+//! └── ... (specific error variants)
+//! ```
+//!
+//! # Examples
+//!
+//! ```
+//! use otc_rfq::application::error::{ApplicationError, InfrastructureError};
+//!
+//! // Create validation error
+//! let err = ApplicationError::validation("quantity must be positive");
+//!
+//! // Create not found error
+//! let err = ApplicationError::not_found("RFQ", "rfq-123");
+//!
+//! // Create infrastructure error
+//! let infra_err = InfrastructureError::database("connection timeout");
+//! let app_err: ApplicationError = infra_err.into();
+//! ```
 
 use crate::domain::errors::DomainError;
+use crate::infrastructure::persistence::RepositoryError;
+use crate::infrastructure::venues::error::VenueError;
 use std::fmt;
 use thiserror::Error;
 
+/// Infrastructure layer error.
+///
+/// Represents errors from external systems and infrastructure components
+/// such as databases, message queues, and external services.
+#[derive(Debug, Error)]
+pub enum InfrastructureError {
+    /// Database error.
+    #[error("database error: {0}")]
+    Database(String),
+
+    /// Network error.
+    #[error("network error: {0}")]
+    Network(String),
+
+    /// Message queue error.
+    #[error("message queue error: {0}")]
+    MessageQueue(String),
+
+    /// Cache error.
+    #[error("cache error: {0}")]
+    Cache(String),
+
+    /// External service error.
+    #[error("external service error: {service} - {message}")]
+    ExternalService {
+        /// Service name.
+        service: String,
+        /// Error message.
+        message: String,
+    },
+
+    /// Configuration error.
+    #[error("configuration error: {0}")]
+    Configuration(String),
+
+    /// Serialization/deserialization error.
+    #[error("serialization error: {0}")]
+    Serialization(String),
+
+    /// Timeout error.
+    #[error("timeout: {0}")]
+    Timeout(String),
+
+    /// Repository error.
+    #[error("repository error: {0}")]
+    Repository(#[from] RepositoryError),
+}
+
+impl InfrastructureError {
+    /// Creates a database error.
+    #[must_use]
+    pub fn database(message: impl Into<String>) -> Self {
+        Self::Database(message.into())
+    }
+
+    /// Creates a network error.
+    #[must_use]
+    pub fn network(message: impl Into<String>) -> Self {
+        Self::Network(message.into())
+    }
+
+    /// Creates a message queue error.
+    #[must_use]
+    pub fn message_queue(message: impl Into<String>) -> Self {
+        Self::MessageQueue(message.into())
+    }
+
+    /// Creates a cache error.
+    #[must_use]
+    pub fn cache(message: impl Into<String>) -> Self {
+        Self::Cache(message.into())
+    }
+
+    /// Creates an external service error.
+    #[must_use]
+    pub fn external_service(service: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::ExternalService {
+            service: service.into(),
+            message: message.into(),
+        }
+    }
+
+    /// Creates a configuration error.
+    #[must_use]
+    pub fn configuration(message: impl Into<String>) -> Self {
+        Self::Configuration(message.into())
+    }
+
+    /// Creates a serialization error.
+    #[must_use]
+    pub fn serialization(message: impl Into<String>) -> Self {
+        Self::Serialization(message.into())
+    }
+
+    /// Creates a timeout error.
+    #[must_use]
+    pub fn timeout(message: impl Into<String>) -> Self {
+        Self::Timeout(message.into())
+    }
+
+    /// Returns true if this error is retryable.
+    #[must_use]
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Network(_) | Self::Timeout(_) | Self::MessageQueue(_)
+        )
+    }
+}
+
 /// Application layer error.
+///
+/// Wraps domain, infrastructure, and venue errors with application-specific
+/// context for use case execution failures.
 #[derive(Debug, Error)]
 pub enum ApplicationError {
+    /// Domain error from business logic.
+    #[error("domain error: {0}")]
+    Domain(#[from] DomainError),
+
+    /// Infrastructure error from external systems.
+    #[error("infrastructure error: {0}")]
+    Infrastructure(#[from] InfrastructureError),
+
+    /// Venue error from liquidity providers.
+    #[error("venue error: {0}")]
+    Venue(#[from] VenueError),
+
+    /// Request validation failed.
+    #[error("validation error: {0}")]
+    Validation(String),
+
+    /// Resource not found.
+    #[error("not found: {resource_type} with id {id}")]
+    NotFound {
+        /// Type of resource.
+        resource_type: String,
+        /// Resource identifier.
+        id: String,
+    },
+
+    /// Authentication or authorization failure.
+    #[error("unauthorized")]
+    Unauthorized,
+
     /// Client not found.
     #[error("client not found: {0}")]
     ClientNotFound(String),
@@ -27,14 +200,6 @@ pub enum ApplicationError {
     /// Compliance check failed.
     #[error("compliance check failed: {0}")]
     ComplianceFailed(String),
-
-    /// Request validation failed.
-    #[error("validation error: {0}")]
-    ValidationError(String),
-
-    /// Domain error.
-    #[error("domain error: {0}")]
-    DomainError(#[from] DomainError),
 
     /// Repository error.
     #[error("repository error: {0}")]
@@ -101,7 +266,22 @@ impl ApplicationError {
     /// Creates a validation error.
     #[must_use]
     pub fn validation(message: impl Into<String>) -> Self {
-        Self::ValidationError(message.into())
+        Self::Validation(message.into())
+    }
+
+    /// Creates a not found error.
+    #[must_use]
+    pub fn not_found(resource_type: impl Into<String>, id: impl Into<String>) -> Self {
+        Self::NotFound {
+            resource_type: resource_type.into(),
+            id: id.into(),
+        }
+    }
+
+    /// Creates an unauthorized error.
+    #[must_use]
+    pub fn unauthorized() -> Self {
+        Self::Unauthorized
     }
 
     /// Creates a repository error.
@@ -121,6 +301,40 @@ impl ApplicationError {
     pub fn internal(message: impl Into<String>) -> Self {
         Self::Internal(message.into())
     }
+
+    /// Returns true if this error is retryable.
+    #[must_use]
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::Infrastructure(e) => e.is_retryable(),
+            Self::Venue(e) => e.is_retryable(),
+            _ => false,
+        }
+    }
+
+    /// Returns true if this is a not found error.
+    #[must_use]
+    pub fn is_not_found(&self) -> bool {
+        matches!(
+            self,
+            Self::NotFound { .. }
+                | Self::ClientNotFound(_)
+                | Self::RfqNotFound(_)
+                | Self::QuoteNotFound(_)
+        )
+    }
+
+    /// Returns true if this is a validation error.
+    #[must_use]
+    pub fn is_validation(&self) -> bool {
+        matches!(self, Self::Validation(_))
+    }
+
+    /// Returns true if this is an authorization error.
+    #[must_use]
+    pub fn is_unauthorized(&self) -> bool {
+        matches!(self, Self::Unauthorized)
+    }
 }
 
 /// Result type for application operations.
@@ -130,10 +344,76 @@ pub type ApplicationResult<T> = Result<T, ApplicationError>;
 mod tests {
     use super::*;
 
+    // InfrastructureError tests
+
+    #[test]
+    fn infrastructure_error_database() {
+        let err = InfrastructureError::database("connection timeout");
+        assert!(err.to_string().contains("database"));
+        assert!(err.to_string().contains("connection timeout"));
+    }
+
+    #[test]
+    fn infrastructure_error_network() {
+        let err = InfrastructureError::network("connection refused");
+        assert!(err.to_string().contains("network"));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn infrastructure_error_message_queue() {
+        let err = InfrastructureError::message_queue("broker unavailable");
+        assert!(err.to_string().contains("message queue"));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn infrastructure_error_cache() {
+        let err = InfrastructureError::cache("redis timeout");
+        assert!(err.to_string().contains("cache"));
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn infrastructure_error_external_service() {
+        let err = InfrastructureError::external_service("pricing-api", "rate limited");
+        assert!(err.to_string().contains("pricing-api"));
+        assert!(err.to_string().contains("rate limited"));
+    }
+
+    #[test]
+    fn infrastructure_error_configuration() {
+        let err = InfrastructureError::configuration("missing API key");
+        assert!(err.to_string().contains("configuration"));
+    }
+
+    #[test]
+    fn infrastructure_error_serialization() {
+        let err = InfrastructureError::serialization("invalid JSON");
+        assert!(err.to_string().contains("serialization"));
+    }
+
+    #[test]
+    fn infrastructure_error_timeout() {
+        let err = InfrastructureError::timeout("request exceeded 5s");
+        assert!(err.to_string().contains("timeout"));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn infrastructure_error_from_repository_error() {
+        let repo_err = RepositoryError::not_found("RFQ", "rfq-123");
+        let infra_err: InfrastructureError = repo_err.into();
+        assert!(infra_err.to_string().contains("rfq-123"));
+    }
+
+    // ApplicationError tests
+
     #[test]
     fn application_error_client_not_found() {
         let err = ApplicationError::client_not_found("client-123");
         assert!(err.to_string().contains("client-123"));
+        assert!(err.is_not_found());
     }
 
     #[test]
@@ -158,6 +438,22 @@ mod tests {
     fn application_error_validation() {
         let err = ApplicationError::validation("quantity must be positive");
         assert!(err.to_string().contains("quantity must be positive"));
+        assert!(err.is_validation());
+    }
+
+    #[test]
+    fn application_error_not_found() {
+        let err = ApplicationError::not_found("RFQ", "rfq-123");
+        assert!(err.to_string().contains("RFQ"));
+        assert!(err.to_string().contains("rfq-123"));
+        assert!(err.is_not_found());
+    }
+
+    #[test]
+    fn application_error_unauthorized() {
+        let err = ApplicationError::unauthorized();
+        assert!(err.to_string().contains("unauthorized"));
+        assert!(err.is_unauthorized());
     }
 
     #[test]
@@ -171,5 +467,53 @@ mod tests {
         let domain_err = DomainError::InvalidQuantity("negative".to_string());
         let app_err: ApplicationError = domain_err.into();
         assert!(app_err.to_string().contains("negative"));
+    }
+
+    #[test]
+    fn application_error_from_infrastructure_error() {
+        let infra_err = InfrastructureError::database("connection failed");
+        let app_err: ApplicationError = infra_err.into();
+        assert!(app_err.to_string().contains("infrastructure"));
+        assert!(app_err.to_string().contains("database"));
+    }
+
+    #[test]
+    fn application_error_from_venue_error() {
+        let venue_err = VenueError::timeout("request timed out");
+        let app_err: ApplicationError = venue_err.into();
+        assert!(app_err.to_string().contains("venue"));
+        assert!(app_err.is_retryable());
+    }
+
+    #[test]
+    fn application_error_retryable_from_infrastructure() {
+        let infra_err = InfrastructureError::network("connection refused");
+        let app_err: ApplicationError = infra_err.into();
+        assert!(app_err.is_retryable());
+    }
+
+    #[test]
+    fn application_error_retryable_from_venue() {
+        let venue_err = VenueError::connection("network error");
+        let app_err: ApplicationError = venue_err.into();
+        assert!(app_err.is_retryable());
+    }
+
+    #[test]
+    fn application_error_not_retryable() {
+        let err = ApplicationError::validation("invalid input");
+        assert!(!err.is_retryable());
+
+        let err = ApplicationError::unauthorized();
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn application_error_is_not_found_variants() {
+        assert!(ApplicationError::not_found("RFQ", "123").is_not_found());
+        assert!(ApplicationError::ClientNotFound("123".to_string()).is_not_found());
+        assert!(ApplicationError::RfqNotFound("123".to_string()).is_not_found());
+        assert!(ApplicationError::QuoteNotFound("123".to_string()).is_not_found());
+        assert!(!ApplicationError::validation("test").is_not_found());
     }
 }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -22,7 +22,7 @@ pub mod services;
 pub mod use_cases;
 
 pub use dto::{CreateRfqRequest, CreateRfqResponse};
-pub use error::{ApplicationError, ApplicationResult};
+pub use error::{ApplicationError, ApplicationResult, InfrastructureError};
 pub use services::{
     execute_with_retry, AggregationConfig, AggregationError, AggregationResult, AlwaysRetryable,
     AmlProvider, AmlResult, BestPriceStrategy, CircuitBreaker, CircuitBreakerConfig,

--- a/src/application/use_cases/collect_quotes.rs
+++ b/src/application/use_cases/collect_quotes.rs
@@ -634,7 +634,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ApplicationError::ValidationError(_)
+            ApplicationError::Validation(_)
         ));
     }
 
@@ -650,7 +650,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ApplicationError::ValidationError(_)
+            ApplicationError::Validation(_)
         ));
     }
 
@@ -673,7 +673,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ApplicationError::ValidationError(_)
+            ApplicationError::Validation(_)
         ));
     }
 

--- a/src/application/use_cases/create_rfq.rs
+++ b/src/application/use_cases/create_rfq.rs
@@ -455,7 +455,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ApplicationError::ValidationError(_)
+            ApplicationError::Validation(_)
         ));
     }
 }


### PR DESCRIPTION
## Summary

Implement application-level error types that wrap domain and infrastructure errors with proper context preservation using thiserror.

## Changes

### InfrastructureError (new)
| Variant | Description |
|---------|-------------|
| `Database` | Database connection/query errors |
| `Network` | Network connectivity errors |
| `MessageQueue` | Message broker errors |
| `Cache` | Cache system errors |
| `ExternalService` | Third-party service errors |
| `Configuration` | Config/setup errors |
| `Serialization` | Encoding/decoding errors |
| `Timeout` | Operation timeout errors |
| `Repository` | Wraps `RepositoryError` via `#[from]` |

### ApplicationError (enhanced)
| Variant | Description |
|---------|-------------|
| `Domain(DomainError)` | Business rule violations via `#[from]` |
| `Infrastructure(InfrastructureError)` | External system failures via `#[from]` |
| `Venue(VenueError)` | Venue-specific errors via `#[from]` |
| `Validation(String)` | Input validation failures |
| `NotFound { resource_type, id }` | Resource not found |
| `Unauthorized` | Authentication/authorization failures |

### Helper Methods
- `InfrastructureError::is_retryable()` - Network, Timeout, MessageQueue are retryable
- `ApplicationError::is_retryable()` - Delegates to wrapped Infrastructure/Venue errors
- `ApplicationError::is_not_found()` - Checks NotFound and specific variants
- `ApplicationError::is_validation()` - Checks Validation variant
- `ApplicationError::is_unauthorized()` - Checks Unauthorized variant

## Technical Decisions

- Used thiserror `#[from]` attribute for automatic error conversion
- `InfrastructureError` wraps `RepositoryError` to unify persistence errors
- `ApplicationError` wraps all lower-layer errors (Domain, Infrastructure, Venue)
- Retryability is determined by delegating to wrapped error types
- Renamed `ValidationError` to `Validation` for consistency with new `NotFound` struct variant

## Testing

- [x] Unit tests added (17 new tests, 809 total)
- [x] InfrastructureError: database, network, message_queue, cache, external_service, configuration, serialization, timeout, from_repository_error
- [x] ApplicationError: from_domain_error, from_infrastructure_error, from_venue_error, not_found, unauthorized, is_retryable, is_not_found

## Checklist

- [x] Code follows `.internalDoc/09-rust-guidelines.md`
- [x] Documentation updated (doc comments on all public items)
- [x] No warnings from `cargo clippy`

Closes #43