### PR TITLE
M6 #122: Integrate IronFix for FIX protocol adapter

### DIFF
--- a/src/infrastructure/venues/fix_config.rs
+++ b/src/infrastructure/venues/fix_config.rs
@@ -1,9 +1,15 @@
 //! # FIX Configuration
 //!
-//! Configuration for FIX sessions.
+//! Configuration for FIX sessions using IronFix.
 //!
 //! This module provides configuration types for FIX protocol sessions
 //! including session parameters, TLS settings, and timeout configuration.
+//!
+//! # IronFix Integration
+//!
+//! The configuration types in this module are designed to work with IronFix:
+//! - [`FixSessionConfig`] provides session parameters compatible with `ironfix_session::SessionConfig`
+//! - [`FixVersion`] maps to IronFix's FIX version strings
 //!
 //! # Examples
 //!

--- a/src/infrastructure/venues/mod.rs
+++ b/src/infrastructure/venues/mod.rs
@@ -18,12 +18,18 @@
 //! - [`FixMMConfig`]: Configuration for FIX market maker
 //! - [`FixSessionConfig`]: FIX session configuration
 //!
+//! ## IronFix Integration
+//!
+//! The FIX adapter uses IronFix for protocol encoding:
+//! - [`fix_adapter::FixEncoder`]: Re-exported `ironfix_tagvalue::Encoder`
+//! - [`fix_messages`]: Type-safe FIX message builders
+//!
 //! ## Implementations
 //!
 //! - `dex`: DEX aggregator adapters
 //! - `rfq_protocols`: RFQ protocol adapters (Hashflow, Bebop)
 //! - `internal_mm`: Internal market maker adapter
-//! - `fix_adapter`: FIX protocol adapter
+//! - `fix_adapter`: FIX protocol adapter with IronFix encoding
 
 pub mod dex;
 pub mod error;


### PR DESCRIPTION
## Summary

Integrate IronFix for FIX protocol encoding in the FixMMAdapter. This adds IronFix-based encoding methods that produce complete, wire-ready FIX messages with proper headers and checksums.

## Changes

- **fix_adapter.rs**:
  - Add `encode_quote_request()` using `ironfix_tagvalue::Encoder`
  - Add `encode_new_order_single()` using `ironfix_tagvalue::Encoder`
  - Re-export `FixEncoder` (`ironfix_tagvalue::Encoder`)
  - Add `fix_version_to_static()` helper function
  - Update module documentation

- **fix_config.rs**:
  - Update documentation to reference IronFix integration

- **mod.rs**:
  - Add IronFix Integration section to documentation

## Technical Decisions

### IronFix Encoding Methods

The new encoding methods produce complete FIX messages:

```rust
// Encode a QuoteRequest using IronFix
let message = adapter.encode_quote_request(&rfq, "QR-001");
// message contains: 8=FIX.4.4|9=...|35=R|49=SENDER|56=TARGET|...10=XXX|
```

Features:
- Automatic BeginString (tag 8) header
- Automatic BodyLength (tag 9) calculation
- Automatic Checksum (tag 10) calculation
- All required session fields (49, 56, 34, 52)
- Message-specific fields

### Backward Compatibility

The existing `build_quote_request()` and `build_new_order_single()` methods are preserved for backward compatibility. The new `encode_*` methods provide the IronFix-based alternative.

## Testing

- [x] Unit tests added/updated
- [x] All 1,277 library tests pass
- [x] Manual testing performed

## Checklist

- [x] Code follows `.internalDoc/09-rust-guidelines.md`
- [x] Documentation updated
- [x] No warnings from `cargo clippy`

Closes #122