### PR TITLE
feat(devops): update Docker images to Alpine 3.23 and add GitHub Acti…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 env:
   CARGO_TERM_COLOR: always
@@ -68,7 +68,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             artifact_name: otc-rfq
             asset_name: otc-rfq-linux-amd64
           - os: macos-latest
@@ -88,6 +88,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install musl-tools (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Install Protobuf Compiler (Linux)
         if: runner.os == 'Linux'
@@ -121,7 +125,7 @@ jobs:
     needs: create-release
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref_name, '-') }}
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -137,6 +141,6 @@ jobs:
 
       - name: Publish to crates.io
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        continue-on-error: true
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        continue-on-error: true

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -8,13 +8,15 @@
 # -----------------------------------------------------------------------------
 # Stage 1: Chef - Prepare dependency recipe
 # -----------------------------------------------------------------------------
-FROM rust:1.83-slim-bookworm AS chef
+FROM rust:1.93-alpine3.23 AS chef
 
-RUN apt-get update && apt-get install -y \
-    pkg-config \
-    libssl-dev \
-    protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    musl-dev \
+    pkgconfig \
+    openssl-dev \
+    openssl-libs-static \
+    protobuf-dev \
+    protoc
 
 RUN cargo install cargo-chef --locked
 
@@ -47,18 +49,17 @@ RUN strip /app/target/release/otc-rfq || true
 # -----------------------------------------------------------------------------
 # Stage 4: Runtime - Minimal production image
 # -----------------------------------------------------------------------------
-FROM debian:bookworm-slim AS runtime
+FROM alpine:3.23 AS runtime
 
 # Install runtime dependencies
-RUN apt-get update && apt-get install -y \
+RUN apk add --no-cache \
     ca-certificates \
     libssl3 \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
+    curl
 
 # Create non-root user for security
-RUN groupadd --gid 1000 otc \
-    && useradd --uid 1000 --gid otc --shell /bin/bash --create-home otc
+RUN addgroup -g 1000 otc \
+    && adduser -u 1000 -G otc -s /bin/sh -D otc
 
 # Create directories for configuration and data
 RUN mkdir -p /app/config /app/data /app/logs \

--- a/Docker/dev.Dockerfile
+++ b/Docker/dev.Dockerfile
@@ -5,24 +5,26 @@
 # Includes all development dependencies and debug symbols
 # =============================================================================
 
-FROM rust:1.83-slim-bookworm
+FROM rust:1.93-alpine3.23
 
 # Install development dependencies
-RUN apt-get update && apt-get install -y \
-    pkg-config \
-    libssl-dev \
-    protobuf-compiler \
+RUN apk add --no-cache \
+    musl-dev \
+    pkgconfig \
+    openssl-dev \
+    openssl-libs-static \
+    protobuf-dev \
+    protoc \
     curl \
-    git \
-    && rm -rf /var/lib/apt/lists/*
+    git
 
 # Install development tools
 RUN cargo install cargo-watch --locked
 RUN cargo install cargo-tarpaulin --locked || true
 
 # Create non-root user for development
-RUN groupadd --gid 1000 dev \
-    && useradd --uid 1000 --gid dev --shell /bin/bash --create-home dev
+RUN addgroup -g 1000 dev \
+    && adduser -u 1000 -G dev -s /bin/sh -D dev
 
 # Create app directory
 RUN mkdir -p /app && chown -R dev:dev /app


### PR DESCRIPTION
…ons workflows

Update Docker configuration to use Alpine 3.23 base images:
- Docker/Dockerfile: Use rust:1.93-alpine3.23 for builder, alpine:3.23 for runtime
- Docker/dev.Dockerfile: Use rust:1.93-alpine3.23
- Replace apt-get with apk package manager
- Use musl-dev, openssl-dev, protobuf-dev for Alpine

Add GitHub Actions workflows:
- .github/workflows/docker.yml: Docker image build and push to ghcr.io
- .github/workflows/release.yml: Release automation with binary builds

docker.yml features:
- Trigger on push to main and version tags
- Build Docker image using Docker/Dockerfile
- Push to GitHub Container Registry (ghcr.io)
- Image tagging: latest, semver, sha
- Trivy vulnerability scanning

release.yml features:
- Trigger on version tags (v*)
- Create GitHub Release with changelog
- Build binaries for Linux (musl), macOS (amd64, arm64)
- Optional crates.io publishing

Closes #145